### PR TITLE
ci: Remove linux submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 *.tar.gz
+linux/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "linux"]
-	path = linux
-	url = git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
-	shallow = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A directory that pulls in everything and builds everything
 
 ```sh
-$ git clone --recursive -j`nproc` git@github.com:ClangBuiltLinux/continuous-integration.git
+$ git clone -j`nproc` git@github.com:ClangBuiltLinux/continuous-integration.git
 $ cd continuous-integration
 $ ./driver.sh
 ```

--- a/driver.sh
+++ b/driver.sh
@@ -36,7 +36,14 @@ build_linux() {
   ccache=$(command -v ccache)
   clang=$(command -v clang-8)
 
-  cd linux
+  if [[ ! -d linux ]]; then
+    git clone --depth=1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    cd linux
+  else
+    cd linux
+    git fetch --depth=1 origin master
+    git reset --hard origin/master
+  fi
   export ARCH=arm64
   export CROSS_COMPILE=aarch64-linux-gnu-
   # Only clean up old artifacts if requested, the Linux build system


### PR DESCRIPTION
At a certain point, Travis can no longer init submodules that aren't up
to date. Move the repo management into the script.

Fixes #8.