### PR TITLE
ci: Switch to Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *.tar.gz
+.ccache
 linux/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,35 +10,13 @@ matrix:
     - name: "ARCH=x86_64"
       env: ARCH=x86_64
 compiler: gcc
-script: ./driver.sh
 os: linux
 dist: trusty
 sudo: required
-addons:
-  apt:
-    packages:
-      - binutils
-      - binutils-aarch64-linux-gnu
-      - binutils-arm-linux-gnueabi
-      - expect-dev
-      - ccache
-cache: ccache
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo add-apt-repository ppa:pietro-monteiro/qemu-backport -y
-before_script:
-  - curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-  - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update -qq
-  - curl -LO http://mirrors.kernel.org/ubuntu/pool/main/s/seabios/seabios_1.8.2-1ubuntu1_all.deb
-  - sudo dpkg -i seabios_1.8.2-1ubuntu1_all.deb
-  - sudo apt-get install clang-8 lld-8 qemu-system-arm qemu-system-x86 -y
-  - mkdir -p ccache
-  - curl https://www.samba.org/ftp/ccache/ccache-3.5.tar.gz | tar -xzf - -C ccache --strip-components=1
-  - cd ccache
-  - ./configure
-  - make -j$(nproc)
-  - export PATH=${PWD}:${PATH}
-  - cd "${OLDPWD}"
+services:
+  - docker
+script:
+  - docker create -v ${TRAVIS_BUILD_DIR}:/travis --name travis debian
+  - docker run --env ARCH=${ARCH} --env LD=${LD} --rm --volumes-from travis debian /bin/bash -c 'cd /travis; ./debian-setup.sh; ./driver.sh'
 after_script:
   - sleep 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@ compiler: gcc
 os: linux
 dist: trusty
 sudo: required
+cache:
+  directories:
+    - .ccache
 services:
   - docker
 script:
   - docker create -v ${TRAVIS_BUILD_DIR}:/travis --name travis debian
-  - docker run --env ARCH=${ARCH} --env LD=${LD} --rm --volumes-from travis debian /bin/bash -c 'cd /travis; ./debian-setup.sh; ./driver.sh'
+  - docker run --env ARCH=${ARCH} --env LD=${LD} --env CCACHE_DIR=/travis/.ccache --env CCACHE_COMPRESS=true --env CCACHE_COMPRESSLEVEL=9 --rm --volumes-from travis debian /bin/bash -c 'cd /travis; ./debian-setup.sh; ./driver.sh; ccache -s'
 after_script:
   - sleep 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ services:
   - docker
 script:
   - docker create -v ${TRAVIS_BUILD_DIR}:/travis --name travis debian
-  - docker run --env ARCH=${ARCH} --env LD=${LD} --env CCACHE_DIR=/travis/.ccache --env CCACHE_COMPRESS=true --env CCACHE_COMPRESSLEVEL=9 --rm --volumes-from travis debian /bin/bash -c 'cd /travis; ./debian-setup.sh; ./driver.sh; ccache -s'
+  - docker run --env ARCH=${ARCH} --env LD=${LD} --env CCACHE_DIR=/travis/.ccache --env CCACHE_COMPRESS=true --env CCACHE_COMPRESSLEVEL=9 --rm --volumes-from travis debian /bin/bash -c 'cd /travis && ./debian-setup.sh && ./driver.sh && ccache -s'
 after_script:
   - sleep 1

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -14,22 +14,23 @@ apt-get upgrade -y
 # is separate from the Clang/lld installation below
 # because we would need to at least install curl to
 # get LLVM's apt key
-apt-get install -y bc \
-                   binutils \
-                   binutils-aarch64-linux-gnu \
-                   binutils-arm-linux-gnueabi \
-                   bison \
-                   ccache \
-                   curl \
-                   flex \
-                   expect \
-                   git \
-                   gnupg \
-                   libssl-dev \
-                   openssl \
-                   make \
-                   qemu-system-arm \
-                   qemu-system-x86
+apt-get install -y \
+    bc \
+    binutils \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabi \
+    bison \
+    ccache \
+    curl \
+    expect \
+    flex \
+    git \
+    gnupg \
+    libssl-dev \
+    make \
+    openssl \
+    qemu-system-arm \
+    qemu-system-x86
 
 # Install nightly verisons of Clang and lld (apt.llvm.org)
 curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Installs all of the necessary packages in a Docker container
-# MUST BE RUN WITH ROOT
 
 # Show all commands and exit upon failure
 set -eux

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Installs all of the necessary packages in a Docker container
+# MUST BE RUN WITH ROOT
+
+apt-get update
+apt-get upgrade -y
+apt-get install -y bc binutils binutils-aarch64-linux-gnu binutils-arm-linux-gnueabi bison ccache curl flex expect gcc git gnupg libssl-dev openssl make qemu-system-arm qemu-system-x86
+curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" | tee -a /etc/apt/sources.list
+apt-get update -qq
+apt-get install -y clang-8 lld-8

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -2,9 +2,36 @@
 # Installs all of the necessary packages in a Docker container
 # MUST BE RUN WITH ROOT
 
+# Show all commands and exit upon failure
+set -eux
+
+# Make sure that all packages are up to date
 apt-get update
 apt-get upgrade -y
-apt-get install -y bc binutils binutils-aarch64-linux-gnu binutils-arm-linux-gnueabi bison ccache curl flex expect gcc git gnupg libssl-dev openssl make qemu-system-arm qemu-system-x86
+
+# Install the official Debian packages that we need
+# curl and wget are not installed by default so this
+# is separate from the Clang/lld installation below
+# because we would need to at least install curl to
+# get LLVM's apt key
+apt-get install -y bc \
+                   binutils \
+                   binutils-aarch64-linux-gnu \
+                   binutils-arm-linux-gnueabi \
+                   bison \
+                   ccache \
+                   curl \
+                   flex \
+                   expect \
+                   git \
+                   gnupg \
+                   libssl-dev \
+                   openssl \
+                   make \
+                   qemu-system-arm \
+                   qemu-system-x86
+
+# Install nightly verisons of Clang and lld (apt.llvm.org)
 curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" | tee -a /etc/apt/sources.list
 apt-get update -qq

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -36,3 +36,9 @@ curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" | tee -a /etc/apt/sources.list
 apt-get update -qq
 apt-get install -y clang-8 lld-8
+
+# By default, Travis's ccache size is around 500MB. We'll
+# start with 2GB just to see how it plays out. Print out
+# the stats as well, it's helpful to see the cache grow.
+ccache -M 2G
+ccache -s

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -5,15 +5,12 @@
 # Show all commands and exit upon failure
 set -eux
 
-# Make sure that all packages are up to date
-apt-get update
-apt-get upgrade -y
-
 # Install the official Debian packages that we need
 # curl and wget are not installed by default so this
 # is separate from the Clang/lld installation below
 # because we would need to at least install curl to
 # get LLVM's apt key
+apt-get update
 apt-get install -y \
     bc \
     binutils \

--- a/driver.sh
+++ b/driver.sh
@@ -96,14 +96,11 @@ mako_reactor() {
   KBUILD_BUILD_TIMESTAMP="Thu Jan  1 00:00:00 UTC 1970" \
   KBUILD_BUILD_USER=driver \
   KBUILD_BUILD_HOST=clangbuiltlinux \
-  make -j"${jobs:-$(nproc)}" CC="${ccache} ${clang}" HOSTCC="${ccache} ${clang}" LD="${LD}" "${@}"
+  make -j"${jobs:-$(nproc)}" CC="${CC}" HOSTCC="${CC}" LD="${LD}" "${@}"
 }
 
 build_linux() {
-  local ccache clang
-  ccache=$(command -v ccache)
-  clang=$(command -v clang-8)
-
+  CC="$(command -v ccache) $(command -v clang-8)"
   if [[ ! -d linux ]]; then
     git clone --depth=1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     cd linux


### PR DESCRIPTION
Unfortunately, as we add new architectures, we are going to need more up
to date binaries that Trusty cannot provide (see #16). Move our building
infrastructure to Docker, which gives us a deterministic, configurable
environment every time. The only forseeable downside is no cacheable
ccache directory so slower builds but we are getting to a point where
constant development is slowing down. I have kept ccache support in
driver.sh so that anyone who uses it locally can still take advantage of
it.

Initially, we'll start with the latest Debian stable but if we need to
move to the unstable version (sid) for more up to date packages, it's as
easy as changing 'debian' to 'debian:sid' in .travis.yml and adjusting
the LLVM/Clang apt repo in debian-setup.sh.