### PR TITLE
.travis.yml: Move ccache configuration into debian-setup.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ services:
   - docker
 script:
   - docker create -v ${TRAVIS_BUILD_DIR}:/travis --name travis debian
-  - docker run --env ARCH=${ARCH} --env LD=${LD} --env CCACHE_DIR=/travis/.ccache --env CCACHE_COMPRESS=true --env CCACHE_COMPRESSLEVEL=9 --rm --volumes-from travis debian /bin/bash -c 'cd /travis && ./debian-setup.sh && ./driver.sh && ccache -s'
+  - docker run --env ARCH=${ARCH} --env LD=${LD} --rm --volumes-from travis debian /bin/bash -c 'cd /travis && ./debian-setup.sh && ./driver.sh && ccache -s'
 after_script:
   - sleep 1

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -35,7 +35,18 @@ apt-get update -qq
 apt-get install -y clang-8 lld-8
 
 # By default, Travis's ccache size is around 500MB. We'll
-# start with 2GB just to see how it plays out. Print out
-# the stats as well, it's helpful to see the cache grow.
+# start with 2GB just to see how it plays out.
 ccache -M 2G
+
+# Enable compression so that we can have more objects in
+# the cache (9 is most compressed, 6 is default)
+ccache --set-config=compression=true
+ccache --set-config=compression_level=9
+
+# Set the cache directory to /travis/.ccache, which we've
+# bind mounted during 'docker create' so that we can keep
+# this cached across builds
+ccache --set-config=cache_dir=/travis/.ccache
+
+# Print out the stats so we actually know the cache grows
 ccache -s


### PR DESCRIPTION
I think this is more intuitive, it makes the 'docker run' command
shorter, and I can document exactly what each cofiguration change
does.