### PR TITLE
ci: Support linux-next

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.tar.gz
 .ccache
 linux/
+linux-next/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 matrix:
   include:
+    # linux
     - name: "ARCH=arm"
       env: ARCH=arm
     - name: "ARCH=arm64"
@@ -9,6 +10,19 @@ matrix:
       env: ARCH=arm64 LD=ld.lld-8
     - name: "ARCH=x86_64"
       env: ARCH=x86_64
+    # linux-next
+    - name: "ARCH=arm REPO=linux-next"
+      env: ARCH=arm REPO=linux-next
+      if: type = cron
+    - name: "ARCH=arm64 REPO=linux-next"
+      env: ARCH=arm64 REPO=linux-next
+      if: type = cron
+    - name: "ARCH=arm64 LD=ld.lld REPO=linux-next"
+      env: ARCH=arm64 LD=ld.lld-8 REPO=linux-next
+      if: type = cron
+    - name: "ARCH=x86_64 REPO=linux-next"
+      env: ARCH=x86_64 REPO=linux-next
+      if: type = cron
 compiler: gcc
 os: linux
 dist: trusty


### PR DESCRIPTION
It's important to test linux-next as that's where all new development happens.

We don't need to build it every branch push and pull request because it is only updated daily so I only have it building with our daily cron.

I have verified it does work properly on my fork: https://travis-ci.com/nathanchance/continuous-integration/builds/90488778