### PR TITLE
debian-setup: quiet down setup, and zero stats

### DIFF
--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -9,8 +9,8 @@ set -eux
 # is separate from the Clang/lld installation below
 # because we would need to at least install curl to
 # get LLVM's apt key
-apt-get update
-apt-get install -y \
+apt-get update -qq
+apt-get install -y -qq \
     bc \
     binutils \
     binutils-aarch64-linux-gnu \
@@ -26,13 +26,15 @@ apt-get install -y \
     make \
     openssl \
     qemu-system-arm \
-    qemu-system-x86
+    qemu-system-x86 \
 
 # Install nightly verisons of Clang and lld (apt.llvm.org)
 curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" | tee -a /etc/apt/sources.list
 apt-get update -qq
-apt-get install -y clang-8 lld-8
+apt-get install -y -qq \
+  clang-8 \
+  lld-8 \
 
 # By default, Travis's ccache size is around 500MB. We'll
 # start with 2GB just to see how it plays out.
@@ -48,5 +50,5 @@ ccache --set-config=compression_level=9
 # this cached across builds
 ccache --set-config=cache_dir=/travis/.ccache
 
-# Print out the stats so we actually know the cache grows
-ccache -s
+# Clear out the stats so we actually know the cache stats
+ccache -z

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -27,7 +27,7 @@ apt-get install -y -qq \
     openssl \
     qemu-system-arm \
     qemu-system-x86 \
-    &>/dev/null
+    >/dev/null
 
 # Install nightly verisons of Clang and lld (apt.llvm.org)
 curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
@@ -36,7 +36,7 @@ apt-get update -qq
 apt-get install -y -qq \
   clang-8 \
   lld-8 \
-  &>/dev/null
+  >/dev/null
 
 # By default, Travis's ccache size is around 500MB. We'll
 # start with 2GB just to see how it plays out.

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -27,6 +27,7 @@ apt-get install -y -qq \
     openssl \
     qemu-system-arm \
     qemu-system-x86 \
+    &>/dev/null
 
 # Install nightly verisons of Clang and lld (apt.llvm.org)
 curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
@@ -35,6 +36,7 @@ apt-get update -qq
 apt-get install -y -qq \
   clang-8 \
   lld-8 \
+  &>/dev/null
 
 # By default, Travis's ccache size is around 500MB. We'll
 # start with 2GB just to see how it plays out.


### PR DESCRIPTION
The logs are full of noise about packages being installed. This is
noise.

Printing the stats before and after makes it hard to tell the difference
without doing math.  It's clearer to zero stats before. Then the stats
after are just for this build.  We don't care about the cache stats pre
run.  Clearing the stats DOES NOT clear the cache itself or reset its
size.

https://ccache.samba.org/manual/latest.html#_options