### PR TITLE
add arm64 LTS targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,20 @@ matrix:
     - name: "ARCH=x86_64 REPO=linux-next"
       env: ARCH=x86_64 REPO=linux-next
       if: type = cron
+    # stable
+    # TODO: re-enable once green
+    #- name: "ARCH=arm64 REPO=4.19"
+      #env: ARCH=arm64 REPO=4.19
+      #if: type = cron
+    - name: "ARCH=arm64 REPO=4.14"
+      env: ARCH=arm64 REPO=4.14
+      if: type = cron
+    #- name: "ARCH=arm64 REPO=4.9"
+      #env: ARCH=arm64 REPO=4.9
+      #if: type = cron
+    #- name: "ARCH=arm64 REPO=4.4"
+      #env: ARCH=arm64 REPO=4.4
+      #if: type = cron
 compiler: gcc
 os: linux
 dist: trusty

--- a/driver.sh
+++ b/driver.sh
@@ -69,6 +69,7 @@ setup_variables() {
       echo "Unknown ARCH specified!"
       exit 1 ;;
   esac
+  export ARCH=${ARCH}
 
   # torvalds/linux is the default repo if nothing is specified
   case ${REPO:=linux} in

--- a/driver.sh
+++ b/driver.sh
@@ -73,9 +73,16 @@ setup_variables() {
 
   # torvalds/linux is the default repo if nothing is specified
   case ${REPO:=linux} in
-    "linux") owner=torvalds ;;
-    "linux-next") owner=next ;;
+    "linux")
+      owner=torvalds ;;
+    "linux-next")
+      owner=next
+      tree=linux-next ;;
+    "4.4"|"4.9"|"4.14"|"4.19")
+      owner=stable
+      branch=linux-${REPO}.y ;;
   esac
+  url=git://git.kernel.org/pub/scm/linux/kernel/git/${owner}/${tree:=linux}.git
 }
 
 check_dependencies() {
@@ -106,13 +113,13 @@ mako_reactor() {
 build_linux() {
   CC="$(command -v ccache) $(command -v clang-8)"
 
-  if [[ -d ${REPO} ]]; then
-    cd ${REPO}
-    git fetch --depth=1 origin master
-    git reset --hard origin/master
+  if [[ -d ${tree} ]]; then
+    cd ${tree}
+    git fetch --depth=1 ${url} ${branch:=master}
+    git reset --hard FETCH_HEAD
   else
-    git clone --depth=1 git://git.kernel.org/pub/scm/linux/kernel/git/${owner}/${REPO}.git
-    cd ${REPO}
+    git clone --depth=1 -b ${branch:=master} --single-branch ${url}
+    cd ${tree}
   fi
 
   git show -s | cat
@@ -138,7 +145,7 @@ build_linux() {
 }
 
 boot_qemu() {
-  local kernel_image=${REPO}/arch/${ARCH}/boot/${image_name}
+  local kernel_image=${tree}/arch/${ARCH}/boot/${image_name}
   # for the rest of the script, particularly qemu
   set -e
   test -e ${kernel_image}

--- a/usage.txt
+++ b/usage.txt
@@ -13,7 +13,13 @@ Environment variables:
   LD:
       If no LD value is specified, ${CROSS_COMPILE}-ld is used. arm64 only.
   REPO:
-      linux (default) or linux-next, to specify which tree to clone and build.
+      Nicknames for trees:
+        linux (default)
+        linux-next
+        4.19
+        4.14
+        4.9
+        4.4
 
 Optional parameters:
   -c | --clean:


### PR DESCRIPTION
this obviously conflicts with #39 , so will rebase on top.

@ajs1984 and I discussed today seeing what was broken in these branches in stable, and sending the relevant backports to @gregkh rather than landing them in Android common kernels, since they merge down from LTS anyways.

We should move these to cron jobs (post submit), but doing so now would make it so that these new targets aren't tested.  Once we get a run, I'll either make the cron, or comment them out (if they're super broken) with a patch on top of this PR.