### PR TITLE
driver: Fix a couple of shellcheck warnings

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -57,10 +57,10 @@ setup_variables() {
       qemu="qemu-system-ppc64"
       qemu_ram=2G
       qemu_cmdline=( -machine powernv
-                     -device ipmi-bmc-sim,id=bmc0
-                     -device isa-ipmi-bt,bmc=bmc0,irq=10
+                     -device "ipmi-bmc-sim,id=bmc0"
+                     -device "isa-ipmi-bt,bmc=bmc0,irq=10"
                      -L /usr/share/skiboot -bios skiboot.lid
-                     -initrd images/ppc64le/rootfs.cpio)
+                     -initrd images/ppc64le/rootfs.cpio )
       export ARCH=powerpc
       export CROSS_COMPILE=powerpc64le-linux-gnu- ;;
 


### PR DESCRIPTION
driver.sh:59:20: warning: Use spaces, not commas, to separate array elements. [SC2054]
driver.sh:60:30: warning: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it. [SC2191]
driver.sh:61:30: warning: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it. [SC2191]

Also, slip in an extra space to match the other qemu_cmdline
definitions.