### PR TITLE
debian-setup: Install libelf-dev

### DIFF
--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -23,6 +23,7 @@ apt-get install -y -qq \
     flex \
     git \
     gnupg \
+    libelf-dev \
     libssl-dev \
     make \
     openssl \


### PR DESCRIPTION
The job failure at [1] appears to have been due to the libelf-dev package being missing. It is available in the sid repositories [2] so we can install it directly.

[1]: https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/157821684#L576
[2]: https://packages.debian.org/sid/libelf-dev