### PR TITLE
debian-setup: Install clang-8, lld-8 and llvm-8 with --no-install-rec…

### DIFF
--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -45,9 +45,10 @@ apt-get install -y -qq \
 curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 echo "deb http://apt.llvm.org/unstable/ llvm-toolchain main" | tee -a /etc/apt/sources.list
 apt-get update -qq
-apt-get install -y -qq \
+apt-get install --no-install-recommends -y -qq \
   clang-8 \
   lld-8 \
+  llvm-8 \
   >/dev/null
 
 # By default, Travis's ccache size is around 500MB. We'll


### PR DESCRIPTION
…ommends option

Check via:

$ apt-get install clang-8 lld-8 -t llvm-toolchain -s

$ apt-get install clang-8 lld-8 llvm-8 --no-install-recommends -t llvm-toolchain -s

CC: Nick Desaulniers
CC: Nathan Chancellor
Suggested-by: Sylvestre Ledru
Signed-off-by: Sedat Dilek