### PR TITLE
.gitignore: mark dirs as toplevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.swp
 *.tar.gz
 .ccache
-linux/
-linux-next/
+/linux/
+/linux-next/


### PR DESCRIPTION
[skip travis]

use `/` prefix to signal ignoring dirs only if they're top level to the
git repo.  Otherwise adding patches to these patch dirs shows no
difference to git (as all dirs with this name are ignored regardless of
depth) and requires `git add -f`.

See also: https://stackoverflow.com/questions/6168736/how-do-i-tell-git-to-ignore-a-specific-filename-only-in-the-repositorys-top-lev