### PR TITLE
driver: arm64: change machine to allow testing KVM HYP

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -37,7 +37,7 @@ setup_variables() {
       image_name=Image.gz
       qemu="qemu-system-aarch64"
       qemu_ram=512m
-      qemu_cmdline=( -machine virt
+      qemu_cmdline=( -machine virt,virtualization=true
                      -cpu cortex-a57
                      -drive "file=images/arm64/rootfs.ext4,format=raw"
                      -append "console=ttyAMA0 root=/dev/vda" )


### PR DESCRIPTION
Speaking with arm64 reviewer Mark Rutland at Linux Plumbers conf 2018
about boot testing at EL2, this was the recommended change he had for us
to make sure we don't regress arm64 KVM HYP, which was an issue in the
past.