### PR TITLE
patches: linux-next: arm64: Fix patch application temporarily

### DIFF
--- a/patches/linux-next/arm64/kaslr.mbox.patch
+++ b/patches/linux-next/arm64/kaslr.mbox.patch
@@ -1,7 +1,71 @@
+From 75a4e03d4d7bcc9da542b74d06be7c31fba3bfd5 Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <natechancellor@gmail.com>
+Date: Sat, 8 Dec 2018 20:21:49 -0700
+Subject: [PATCH 1/3] Revert "arm64: relocatable: fix inconsistencies in linker
+ script and options"
+
+To make sure that we have working continuous integration while we wait
+for the lld patches to land.
+
+This reverts commit 3bbd3db86470c701091fb1d67f1fab6621debf50.
+
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+---
+ arch/arm64/Makefile             | 2 +-
+ arch/arm64/kernel/vmlinux.lds.S | 9 ++++-----
+ 2 files changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
+index 6896f17db692..99e7d08c6083 100644
+--- a/arch/arm64/Makefile
++++ b/arch/arm64/Makefile
+@@ -18,7 +18,7 @@ ifeq ($(CONFIG_RELOCATABLE), y)
+ # Pass --no-apply-dynamic-relocs to restore pre-binutils-2.27 behaviour
+ # for relative relocs, since this leads to better Image compression
+ # with the relocation offsets always being zero.
+-LDFLAGS_vmlinux		+= -shared -Bsymbolic -z notext -z norelro \
++LDFLAGS_vmlinux		+= -pie -shared -Bsymbolic \
+ 			$(call ld-option, --no-apply-dynamic-relocs)
+ endif
+ 
+diff --git a/arch/arm64/kernel/vmlinux.lds.S b/arch/arm64/kernel/vmlinux.lds.S
+index 7fa008374907..03b00007553d 100644
+--- a/arch/arm64/kernel/vmlinux.lds.S
++++ b/arch/arm64/kernel/vmlinux.lds.S
+@@ -99,8 +99,7 @@ SECTIONS
+ 		*(.discard)
+ 		*(.discard.*)
+ 		*(.interp .dynamic)
+-		*(.dynsym .dynstr .hash .gnu.hash)
+-		*(.eh_frame)
++		*(.dynsym .dynstr .hash)
+ 	}
+ 
+ 	. = KIMAGE_VADDR + TEXT_OFFSET;
+@@ -193,12 +192,12 @@ SECTIONS
+ 
+ 	PERCPU_SECTION(L1_CACHE_BYTES)
+ 
+-	.rela.dyn : ALIGN(8) {
++	.rela : ALIGN(8) {
+ 		*(.rela .rela*)
+ 	}
+ 
+-	__rela_offset	= ABSOLUTE(ADDR(.rela.dyn) - KIMAGE_VADDR);
+-	__rela_size	= SIZEOF(.rela.dyn);
++	__rela_offset	= ABSOLUTE(ADDR(.rela) - KIMAGE_VADDR);
++	__rela_size	= SIZEOF(.rela);
+ 
+ 	. = ALIGN(SEGMENT_ALIGN);
+ 	__initdata_end = .;
+-- 
+2.20.0.rc2
+
+
 From 4a0f4c1e201e223f5b0c75031d7747404c60723a Mon Sep 17 00:00:00 2001
 From: Ard Biesheuvel <ard.biesheuvel@linaro.org>
 Date: Sat, 1 Dec 2018 12:53:24 +0100
-Subject: [PATCH 1/2] arm64: relocatable: build the kernel as a proper shared
+Subject: [PATCH 2/3] arm64: relocatable: build the kernel as a proper shared
  library
 
 readelf complains about the section layout of vmlinux when building
@@ -120,7 +184,7 @@ index 03b00007553d..9ba4016090b1 100644
 From a1362f1f512e8c7d099a78dd9b3cd4f9c279dc45 Mon Sep 17 00:00:00 2001
 From: Ard Biesheuvel <ard.biesheuvel@linaro.org>
 Date: Sat, 1 Dec 2018 14:57:34 +0100
-Subject: [PATCH 2/2] arm64: add support for building the KASLR kernel with
+Subject: [PATCH 3/3] arm64: add support for building the KASLR kernel with
  LLVM lld
 
 Work around some differences in the behavior of ld.lld as compared


### PR DESCRIPTION
The patches in this repo assumed that this would fully be fixed in the
kernel but due to review discussion, it will now be fixed in the kernel
and lld. While the lld patches await acceptance/review, temporarily
revert the accepted commit in the kernel and use the previous versions
so CI continues to pass. Once the lld patches have been accepted and
apt.llvm.org has a version with them available, the entire mbox file can
be removed.