### PR TITLE
driver: Improvements around binary locating

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -139,14 +139,72 @@ setup_variables() {
 }
 
 check_dependencies() {
+  # Check for existence of needed binaries
   command -v nproc
   command -v "${CROSS_COMPILE:-}"as
   command -v ${qemu}
   command -v timeout
   command -v unbuffer
-  command -v clang-9
-  command -v llvm-ar-9
-  command -v "${LD:="${CROSS_COMPILE:-}"ld}"
+
+  # Check for LD, CC, and AR environmental variables
+  # and print the version string of each. If CC and AR
+  # don't exist, try to find them.
+  # lld isn't ready for all architectures so it's just
+  # simpler to fall back to GNU ld when LD isn't specified
+  # to avoid architecture specific selection logic.
+
+  "${LD:="${CROSS_COMPILE:-}"ld}" --version
+
+  if [[ -z "${CC:-}" ]]; then
+    for CC in clang-9 clang-8 clang-7 clang; do
+      command -v ${CC} &>/dev/null && break
+    done
+  fi
+  ${CC} --version 2>/dev/null || {
+    set +x
+    echo
+    echo "Looks like ${CC} could not be found in PATH!"
+    echo
+    echo "Please install as recent a version of clang as you can from your distro or"
+    echo "properly specify the CC variable to point to the correct clang binary."
+    echo
+    echo "If you don't want to install clang, you can either download AOSP's prebuilt"
+    echo "clang [1] or build it from source [2] then add the bin folder to your PATH."
+    echo
+    echo "[1]: https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/"
+    echo "[2]: https://github.com/ClangBuiltLinux/linux/wiki/Building-Clang-from-source"
+    echo
+    exit;
+  }
+
+  if [[ -z "${AR:-}" ]]; then
+    for AR in llvm-ar-9 llvm-ar-8 llvm-ar-7 llvm-ar "${CROSS_COMPILE:-}"ar; do
+      command -v ${AR} 2>/dev/null && break
+    done
+  fi
+  check_ar_version
+  ${AR} --version
+}
+
+# Optimistically check to see that the user has a llvm-ar
+# with https://reviews.llvm.org/rL354044. If they don't,
+# fall back to GNU ar and let them know.
+check_ar_version() {
+  if ${AR} --version | grep -q "LLVM" && \
+     [[ $(${AR} --version | grep version | sed -e 's/.*LLVM version //g' -e 's/[[:blank:]]*$//' -e 's/\.//g') -lt 900 ]]; then
+    set +x
+    echo
+    echo "${AR} found but appears to be too old to build the kernel (needs to be at least 9.0.0)."
+    echo
+    echo "Please either update llvm-ar from your distro or build it from source!"
+    echo
+    echo "See https://github.com/ClangBuiltLinux/linux/issues/33 for more info."
+    echo
+    echo "Falling back to GNU ar..."
+    echo
+    AR=${CROSS_COMPILE:-}ar
+    set -x
+  fi
 }
 
 mako_reactor() {
@@ -155,11 +213,12 @@ mako_reactor() {
   KBUILD_BUILD_TIMESTAMP="Thu Jan  1 00:00:00 UTC 1970" \
   KBUILD_BUILD_USER=driver \
   KBUILD_BUILD_HOST=clangbuiltlinux \
-  make -j"${jobs:-$(nproc)}" CC="${CC}" HOSTCC="${CC}" LD="${LD}" HOSTLD="${HOSTLD:-ld}" AR="llvm-ar-9" "${@}"
+  make -j"${jobs:-$(nproc)}" CC="${CC}" HOSTCC="${CC}" LD="${LD}" HOSTLD="${HOSTLD:-ld}" AR="${AR}" "${@}"
 }
 
 build_linux() {
-  CC="$(command -v ccache) $(command -v clang-9)"
+  # Wrap CC in ccache if it is available (it's not strictly required)
+  CC="$(command -v ccache) ${CC}"
   [[ ${LD} =~ lld ]] && HOSTLD=${LD}
 
   if [[ -d ${tree} ]]; then

--- a/driver.sh
+++ b/driver.sh
@@ -5,6 +5,7 @@ set -eu
 setup_variables() {
   while [[ ${#} -ge 1 ]]; do
     case ${1} in
+      "AR="*|"ARCH="*|"CC="*|"LD="*|"REPO="*) export "${1?}" ;;
       "-c"|"--clean") cleanup=true ;;
       "-j"|"--jobs") shift; jobs=$1 ;;
       "-j"*) jobs=${1/-j} ;;

--- a/usage.txt
+++ b/usage.txt
@@ -4,14 +4,23 @@ Script description: Build a Linux kernel image with Clang and boot it
 
 Environment variables:
   The script can take into account specific environment variables, mostly used
-  with Travis.  They can be invoked either via 'export VAR=<value>;
-  ./driver.sh' OR 'VAR=value ./driver.sh'
+  with Travis.  They can be invoked in one of three ways:
+    $ export VAR=<value> && ./driver.sh
+    $ VAR=value ./driver.sh
+    $ ./driver.sh VAR=value
 
+  AR:
+      If no AR value is specified, the script will attempt to set AR to
+      llvm-ar-9, llvm-ar-8, llvm-ar-7, llvm-ar, then ${CROSS_COMPILE}ar
+      if they are found in PATH.
   ARCH:
       If no ARCH value is specified, arm64 is the default. Currently, arm32_v7,
       arm32_v6, arm32_v5, arm64, ppc64le and x86_64 are supported.
+  CC:
+      If no CC value is specified, the script will attempt to set CC to
+      clang-9, clang-8, clang-7, then clang if they are found in PATH.
   LD:
-      If no LD value is specified, ${CROSS_COMPILE}-ld is used. arm64 only.
+      If no LD value is specified, ${CROSS_COMPILE}ld is used. arm64 only.
   REPO:
       Nicknames for trees:
         linux (default)


### PR DESCRIPTION
We've tailored driver.sh around our Docker image with regards to the
binary versions that we check for. A user might not have the latest
versions of Clang or llvm-ar installed. Check for all three versions
offered by apt.llvm.org, falling back to the generic binary name if
those are not found.

Additionally, for llvm-ar, do a sanity check that the user has a version
of llvm-ar that can actually build the kernel (has support for the P
modifier). If they don't fall back to regular GNU ar and let them know.

Presubmit: https://travis-ci.com/nathanchance/continuous-integration/builds/103470578