### PR TITLE
driver: Fix check_ar_version with LLVM source builds

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -191,7 +191,7 @@ check_dependencies() {
 # fall back to GNU ar and let them know.
 check_ar_version() {
   if ${AR} --version | grep -q "LLVM" && \
-     [[ $(${AR} --version | grep version | sed -e 's/.*LLVM version //g' -e 's/[[:blank:]]*$//' -e 's/\.//g') -lt 900 ]]; then
+     [[ $(${AR} --version | grep version | sed -e 's/.*LLVM version //g' -e 's/[[:blank:]]*$//' -e 's/\.//g' -e 's/svn//' ) -lt 900 ]]; then
     set +x
     echo
     echo "${AR} found but appears to be too old to build the kernel (needs to be at least 9.0.0)."


### PR DESCRIPTION
`llvm-ar` will have `svn` in its version by default (when
`LLVM_VERSION_SUFFIX` is not set to anything during cmake).

```
+ check_ar_version
+ llvm-ar --version
+ grep -q LLVM
++ llvm-ar --version
++ grep version
++ sed -e 's/.*LLVM version //g' -e 's/[[:blank:]]*$//' -e 's/\.//g'
+ [[ 900svn -lt 900 ]]
./driver.sh: line 195: [[: 900svn: value too great for base (error token is "900svn")
```