### PR TITLE
driver: Dump the comment section of vmlinux

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -141,6 +141,10 @@ check_dependencies() {
   command -v timeout
   command -v unbuffer
 
+  for readelf in llvm-readelf-9 llvm-readelf-8 llvm-readelf-7 llvm-readelf; do
+    command -v ${readelf} &>/dev/null && break
+  done
+
   # Check for LD, CC, and AR environmental variables
   # and print the version string of each. If CC and AR
   # don't exist, try to find them.
@@ -259,6 +263,7 @@ build_linux() {
   mako_reactor olddefconfig &>/dev/null
   mako_reactor ${image_name}
   [[ $ARCH =~ arm ]] && mako_reactor dtbs
+  ${readelf} --string-dump=.comment vmlinux
 
   cd "${OLDPWD}"
 }


### PR DESCRIPTION
This will help verify that LLD is working for linking.

```
+ readelf --string-dump=.comment vmlinux

String dump of section '.comment':
  [     0]  clang version 9.0.0 (git://github.com/llvm/llvm-project c84107612ad7c73679996b6b0fb39a7423f0058d)
  [    62]  Linker: LLD 9.0.0 (git://github.com/llvm/llvm-project c84107612ad7c73679996b6b0fb39a7423f0058d)
```