### PR TITLE
patches: linux-next: x86_64: Refresh

### DIFF
--- a/patches/linux-next/x86_64/x86-series.patch
+++ b/patches/linux-next/x86_64/x86-series.patch
@@ -1,1 +1,246 @@
-../../linux/x86_64/x86-series.patch
+From aef1d9a42c562406030cb0f4ba9fab7e9b7d5145 Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <natechancellor@gmail.com>
+Date: Sat, 5 Jan 2019 11:51:39 -0700
+Subject: [PATCH 1/2] DO-NOT-UPSTREAM: x86: Revert two commits that break the
+ build with Clang
+
+* 4a789213c9a5 ("x86 uaccess: Introduce __put_user_goto")
+* a959dc88f9c8 ("Use __put_user_goto in __put_user_size() and unsafe_put_user()")
+
+We've been fortunate enough to get around the asm goto requirement
+introduced in commit e501ce957a78 ("x86: Force asm-goto") until now.
+
+This is not a clean revert because of commit 2a418cf3f5f1 ("x86/uaccess:
+Don't leak the AC flag into __put_user() value evaluation").
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/6
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+---
+ arch/x86/include/asm/uaccess.h | 80 +++++++++++++++++-----------------
+ 1 file changed, 41 insertions(+), 39 deletions(-)
+
+diff --git a/arch/x86/include/asm/uaccess.h b/arch/x86/include/asm/uaccess.h
+index 22ba683afdc2..9352dbef0fdd 100644
+--- a/arch/x86/include/asm/uaccess.h
++++ b/arch/x86/include/asm/uaccess.h
+@@ -182,14 +182,19 @@ __typeof__(__builtin_choose_expr(sizeof(x) > sizeof(0UL), 0ULL, 0UL))
+ 
+ 
+ #ifdef CONFIG_X86_32
+-#define __put_user_goto_u64(x, addr, label)			\
+-	asm_volatile_goto("\n"					\
+-		     "1:	movl %%eax,0(%1)\n"		\
+-		     "2:	movl %%edx,4(%1)\n"		\
+-		     _ASM_EXTABLE_UA(1b, %l2)			\
+-		     _ASM_EXTABLE_UA(2b, %l2)			\
+-		     : : "A" (x), "r" (addr)			\
+-		     : : label)
++#define __put_user_asm_u64(x, addr, err, errret)			\
++	asm volatile("\n"						\
++		     "1:	movl %%eax,0(%2)\n"			\
++		     "2:	movl %%edx,4(%2)\n"			\
++		     "3:"						\
++		     ".section .fixup,\"ax\"\n"				\
++		     "4:	movl %3,%0\n"				\
++		     "	jmp 3b\n"					\
++		     ".previous\n"					\
++		     _ASM_EXTABLE_UA(1b, 4b)				\
++		     _ASM_EXTABLE_UA(2b, 4b)				\
++		     : "=r" (err)					\
++		     : "A" (x), "r" (addr), "i" (errret), "0" (err))
+ 
+ #define __put_user_asm_ex_u64(x, addr)					\
+ 	asm volatile("\n"						\
+@@ -204,8 +209,8 @@ __typeof__(__builtin_choose_expr(sizeof(x) > sizeof(0UL), 0ULL, 0UL))
+ 	asm volatile("call __put_user_8" : "=a" (__ret_pu)	\
+ 		     : "A" ((typeof(*(ptr)))(x)), "c" (ptr) : "ebx")
+ #else
+-#define __put_user_goto_u64(x, ptr, label) \
+-	__put_user_goto(x, ptr, "q", "", "er", label)
++#define __put_user_asm_u64(x, ptr, retval, errret) \
++	__put_user_asm(x, ptr, retval, "q", "", "er", errret)
+ #define __put_user_asm_ex_u64(x, addr)	\
+ 	__put_user_asm_ex(x, addr, "q", "", "er")
+ #define __put_user_x8(x, ptr, __ret_pu) __put_user_x(8, x, ptr, __ret_pu)
+@@ -266,21 +271,22 @@ extern void __put_user_8(void);
+ 	__builtin_expect(__ret_pu, 0);				\
+ })
+ 
+-#define __put_user_size(x, ptr, size, label)				\
++#define __put_user_size(x, ptr, size, retval, errret)			\
+ do {									\
++	retval = 0;							\
+ 	__chk_user_ptr(ptr);						\
+ 	switch (size) {							\
+ 	case 1:								\
+-		__put_user_goto(x, ptr, "b", "b", "iq", label);	\
++		__put_user_asm(x, ptr, retval, "b", "b", "iq", errret);	\
+ 		break;							\
+ 	case 2:								\
+-		__put_user_goto(x, ptr, "w", "w", "ir", label);		\
++		__put_user_asm(x, ptr, retval, "w", "w", "ir", errret);	\
+ 		break;							\
+ 	case 4:								\
+-		__put_user_goto(x, ptr, "l", "k", "ir", label);		\
++		__put_user_asm(x, ptr, retval, "l", "k", "ir", errret);	\
+ 		break;							\
+ 	case 8:								\
+-		__put_user_goto_u64(x, ptr, label);			\
++		__put_user_asm_u64(x, ptr, retval, errret);		\
+ 		break;							\
+ 	default:							\
+ 		__put_user_bad();					\
+@@ -425,14 +431,11 @@ do {									\
+ 
+ #define __put_user_nocheck(x, ptr, size)			\
+ ({								\
+-	__label__ __pu_label;					\
+-	int __pu_err = -EFAULT;					\
++	int __pu_err;						\
+ 	__typeof__(*(ptr)) __pu_val;				\
+ 	__pu_val = x;						\
+ 	__uaccess_begin();					\
+-	__put_user_size(__pu_val, (ptr), (size), __pu_label);	\
+-	__pu_err = 0;						\
+-__pu_label:							\
++	__put_user_size(__pu_val, (ptr), (size), __pu_err, -EFAULT);\
+ 	__uaccess_end();					\
+ 	__builtin_expect(__pu_err, 0);				\
+ })
+@@ -457,23 +460,17 @@ struct __large_struct { unsigned long buf[100]; };
+  * we do not write to any memory gcc knows about, so there are no
+  * aliasing issues.
+  */
+-#define __put_user_goto(x, addr, itype, rtype, ltype, label)	\
+-	asm_volatile_goto("\n"						\
+-		"1:	mov"itype" %"rtype"0,%1\n"			\
+-		_ASM_EXTABLE_UA(1b, %l2)					\
+-		: : ltype(x), "m" (__m(addr))				\
+-		: : label)
+-
+-#define __put_user_failed(x, addr, itype, rtype, ltype, errret)		\
+-	({	__label__ __puflab;					\
+-		int __pufret = errret;					\
+-		__put_user_goto(x,addr,itype,rtype,ltype,__puflab);	\
+-		__pufret = 0;						\
+-	__puflab: __pufret; })
+-
+-#define __put_user_asm(x, addr, retval, itype, rtype, ltype, errret)	do {	\
+-	retval = __put_user_failed(x, addr, itype, rtype, ltype, errret);	\
+-} while (0)
++#define __put_user_asm(x, addr, err, itype, rtype, ltype, errret)	\
++	asm volatile("\n"						\
++		     "1:	mov"itype" %"rtype"1,%2\n"		\
++		     "2:\n"						\
++		     ".section .fixup,\"ax\"\n"				\
++		     "3:	mov %3,%0\n"				\
++		     "	jmp 2b\n"					\
++		     ".previous\n"					\
++		     _ASM_EXTABLE_UA(1b, 3b)				\
++		     : "=r"(err)					\
++		     : ltype(x), "m" (__m(addr)), "i" (errret), "0" (err))
+ 
+ #define __put_user_asm_ex(x, addr, itype, rtype, ltype)			\
+ 	asm volatile("1:	mov"itype" %"rtype"0,%1\n"		\
+@@ -717,8 +714,13 @@ static __must_check __always_inline bool user_access_begin(const void __user *pt
+ #define user_access_save()	smap_save()
+ #define user_access_restore(x)	smap_restore(x)
+ 
+-#define unsafe_put_user(x, ptr, label)	\
+-	__put_user_size((__typeof__(*(ptr)))(x), (ptr), sizeof(*(ptr)), label)
++#define unsafe_put_user(x, ptr, err_label)					\
++do {										\
++	int __pu_err;								\
++	__typeof__(*(ptr)) __pu_val = (x);					\
++	__put_user_size(__pu_val, (ptr), sizeof(*(ptr)), __pu_err, -EFAULT);	\
++	if (unlikely(__pu_err)) goto err_label;					\
++} while (0)
+ 
+ #define unsafe_get_user(x, ptr, err_label)					\
+ do {										\
+-- 
+2.21.0
+
+
+From fdd79fe62ad7170ba301686ff66750959d6d53f1 Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <natechancellor@gmail.com>
+Date: Tue, 25 Sep 2018 13:32:33 -0700
+Subject: [PATCH 2/2] DO-NOT-UPSTREAM: x86: Avoid warnings/errors due to lack
+ of asm goto
+
+We don't want to see an inordinate amount of warning spam from
+the BPF samples and after reverting commits 4a789213c9a5 ("x86
+uaccess: Introduce __put_user_goto") and a959dc88f9c8 ("Use
+__put_user_goto in __put_user_size() and unsafe_put_user()"), we
+can successfully compile an x86 kernel with Clang.
+
+This is obviously not a long term solution. LLVM/Clang support for
+asm goto can be tracked at the below link.
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/6
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+---
+ arch/x86/Makefile                     | 9 +++++----
+ arch/x86/boot/compressed/Makefile     | 3 +++
+ drivers/firmware/efi/libstub/Makefile | 4 ++++
+ 3 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/arch/x86/Makefile b/arch/x86/Makefile
+index 56e748a7679f..9237af36280b 100644
+--- a/arch/x86/Makefile
++++ b/arch/x86/Makefile
+@@ -227,6 +227,11 @@ ifdef CONFIG_RETPOLINE
+   endif
+ endif
+ 
++# Avoid warnings in arch/x86/include/asm/cpufeature.h when building with Clang
++ifndef CONFIG_CC_HAS_ASM_GOTO
++  KBUILD_CFLAGS += -D__BPF_TRACING__
++endif
++
+ archscripts: scripts_basic
+ 	$(Q)$(MAKE) $(build)=arch/x86/tools relocs
+ 
+@@ -297,10 +302,6 @@ vdso_install:
+ 
+ archprepare: checkbin
+ checkbin:
+-ifndef CONFIG_CC_HAS_ASM_GOTO
+-	@echo Compiler lacks asm-goto support.
+-	@exit 1
+-endif
+ ifdef CONFIG_RETPOLINE
+ ifeq ($(RETPOLINE_CFLAGS),)
+ 	@echo "You are building kernel with non-retpoline compiler." >&2
+diff --git a/arch/x86/boot/compressed/Makefile b/arch/x86/boot/compressed/Makefile
+index 6b84afdd7538..c7265084dd78 100644
+--- a/arch/x86/boot/compressed/Makefile
++++ b/arch/x86/boot/compressed/Makefile
+@@ -38,6 +38,9 @@ KBUILD_CFLAGS += $(call cc-option,-fno-stack-protector)
+ KBUILD_CFLAGS += $(call cc-disable-warning, address-of-packed-member)
+ KBUILD_CFLAGS += $(call cc-disable-warning, gnu)
+ KBUILD_CFLAGS += -Wno-pointer-sign
++ifndef CONFIG_CC_HAS_ASM_GOTO
++KBUILD_CFLAGS += -D__BPF_TRACING__
++endif
+ 
+ KBUILD_AFLAGS  := $(KBUILD_CFLAGS) -D__ASSEMBLY__
+ GCOV_PROFILE := n
+diff --git a/drivers/firmware/efi/libstub/Makefile b/drivers/firmware/efi/libstub/Makefile
+index 0460c7581220..315f43ea5b0c 100644
+--- a/drivers/firmware/efi/libstub/Makefile
++++ b/drivers/firmware/efi/libstub/Makefile
+@@ -24,6 +24,10 @@ cflags-$(CONFIG_ARM)		:= $(subst $(CC_FLAGS_FTRACE),,$(KBUILD_CFLAGS)) \
+ 
+ cflags-$(CONFIG_EFI_ARMSTUB)	+= -I$(srctree)/scripts/dtc/libfdt
+ 
++ifndef CONFIG_CC_HAS_ASM_GOTO
++cflags-$(CONFIG_X86)		+= -D__BPF_TRACING__
++endif
++
+ KBUILD_CFLAGS			:= $(cflags-y) -DDISABLE_BRANCH_PROFILING \
+ 				   -D__NO_FORTIFY \
+ 				   $(call cc-option,-ffreestanding) \
+-- 
+2.21.0
+


### PR DESCRIPTION
Commit e74deb11931f ("x86/uaccess: Introduce user_access_{save,restore}()")
in -next prevents the patch from applying cleanly, even with the three
way merge flag.

Link: https://git.kernel.org/tip/e74deb11931ff682b59d5b9d387f7115f689698e

Fixes: https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/192907812

Presubmit: https://travis-ci.com/nathanchance/continuous-integration/jobs/193055531