### PR TITLE
patches: Remove bcmp patch for 4.9 to 4.19

### DIFF
--- a/patches/4.14/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
+++ b/patches/4.14/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
@@ -1,1 +1,0 @@
-../../4.4/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch

--- a/patches/4.19/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
+++ b/patches/4.19/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
@@ -1,1 +1,0 @@
-../../4.4/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch

--- a/patches/4.9/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
+++ b/patches/4.9/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
@@ -1,1 +1,0 @@
-../../4.4/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch

--- a/patches/common-4.14/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
+++ b/patches/common-4.14/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
@@ -1,1 +1,0 @@
-../../4.4/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch

--- a/patches/common-4.19/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
+++ b/patches/common-4.19/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
@@ -1,1 +1,0 @@
-../../4.4/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch

--- a/patches/common-4.9/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
+++ b/patches/common-4.9/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch
@@ -1,1 +1,0 @@
-../../4.4/all/v4-0001-lib-string.c-implement-a-basic-bcmp.patch


### PR DESCRIPTION
The patch has been released in 4.9.169, 4.14.112, and 4.19.35.

Fixes the following Travis fails: https://travis-ci.com/ClangBuiltLinux/continuous-integration/builds/108808195