### PR TITLE
travis: Remove arm64 lld build with LLVM 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,9 +156,6 @@ matrix:
     - name: "ARCH=arm64 LLVM_VERSION=8"
       env: ARCH=arm64 LLVM_VERSION=8
       if: type = cron
-    - name: "ARCH=arm64 LD=ld.lld LLVM_VERSION=8"
-      env: ARCH=arm64 LD=ld.lld-8 LLVM_VERSION=8
-      if: type = cron
     - name: "ARCH=ppc32 LLVM_VERSION=8"
       env: ARCH=ppc32 LLVM_VERSION=8
       if: type = cron


### PR DESCRIPTION
This will never pass because LLD 8 does not support '-n'.

Failure: https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/198494196

Cause: https://git.kernel.org/linus/691efbedc60d2a7364a90e38882fc762f06f52c4