### PR TITLE
driver: Disable LTO/CFI by default

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -9,6 +9,7 @@ setup_variables() {
       "-c"|"--clean") cleanup=true ;;
       "-j"|"--jobs") shift; jobs=$1 ;;
       "-j"*) jobs=${1/-j} ;;
+      "--lto") disable_lto=false ;;
       "-h"|"--help")
         cat usage.txt
         exit 0 ;;
@@ -269,6 +270,8 @@ build_linux() {
     [[ $ARCH != "x86_64" ]] && cat ../configs/tt.config >> .config
     # Disable ftrace on arm32: https://github.com/ClangBuiltLinux/linux/issues/35
     [[ $ARCH == "arm" ]] && ./scripts/config -d CONFIG_FTRACE
+    # Disable LTO and CFI unless explicitly requested
+    ${disable_lto:=true} && ./scripts/config -d CONFIG_LTO -d CONFIG_LTO_CLANG
   fi
   # Make sure we build with CONFIG_DEBUG_SECTION_MISMATCH so that the
   # full warning gets printed and we can file and fix it properly.

--- a/usage.txt
+++ b/usage.txt
@@ -42,3 +42,7 @@ Optional parameters:
   -j | --jobs
       Pass this value to make. The script will use all cores by default but
       this isn't always the best value.
+  --lto
+      By default, the script turns off LTO/CFI for quicker build times. If
+      your machine can handle the more intensive compile, pass this flag
+      to avoid attempting to disable it. This does not enable LTO explicitly.


### PR DESCRIPTION
This is now enabled by default on Cuttlefish 4.19, which causes issues
with our Debian setup because we do not have llvm-nm installed and it is
hardcoded that way in the Makefile:

https://github.com/aosp-mirror/kernel_common/blob/50f91435a27a9f7/Makefile#L617

It might be worth making that customizable in the future; however,
Travis cannot handle LTO for both time and memory reasons so just
disable it by default. A user can still pass '--lto' to driver.sh
to avoid disabling LTO (it will NOT attempt to enable it).

Fixes: https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/202781149

Presubmit: https://travis-ci.com/nathanchance/continuous-integration/builds/113113278