### PR TITLE
travis: Fix x86_64 LLVM 8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ matrix:
       env: ARCH=ppc64le LLVM_VERSION=8
       if: type = cron
     - name: "ARCH=x86_64 LLVM_VERSION=8"
-      env: ARCH=x86_64
+      env: ARCH=x86_64 LLVM_VERSION=8
       if: type = cron
 compiler: gcc
 os: linux


### PR DESCRIPTION
This has always been an LLVM 9 build since LLVM_VERSION wasn't being set... whoops.