### PR TITLE
driver.sh: Use KVM when possible

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -99,6 +99,8 @@ setup_variables() {
           qemu_cmdline=( -drive "file=images/x86_64/rootfs.ext4,format=raw,if=ide"
                          -append "console=ttyS0 root=/dev/sda" ) ;;
       esac
+      # Use KVM if the processor supports it (first part) and the KVM module is loaded (second part)
+      [[ $(grep -c -E 'vmx|svm' /proc/cpuinfo) -gt 0 && $(lsmod 2>/dev/null | grep -c kvm) -gt 0 ]] && qemu_cmdline=( "${qemu_cmdline[@]}" -enable-kvm )
       image_name=bzImage
       qemu="qemu-system-x86_64" ;;
     "ppc32")


### PR DESCRIPTION
This speeds up my local boots by 10s on average (24s to 14s).

We cannot unconditionally enable this because some machines (like the
ones on Travis CI) do not have KVM support, which would cause an error:

Could not access KVM kernel module: No such file or directory
qemu-system-x86_64: failed to initialize KVM: No such file or directory

https://travis-ci.com/nathanchance/continuous-integration/jobs/205427268

Check that the CPU supports virtualization from /proc/cpuinfo and that
the kvm module is enabled. As far as I can tell, every major
distribution sets CONFIG_KVM to m.

This is primarily aimed at local development (especially after #172) but
Travis may eventually gain virtualization support, which would speed up
CI.

Presubmit: https://travis-ci.com/nathanchance/continuous-integration/builds/114330882