### PR TITLE
patches: llvm-8: arm: Fix conflicts in common-page-size patch

### DIFF
--- a/patches/llvm-8/linux/arm/0001-ARM-8860-1-VDSO-Drop-implicit-common-page-size-linke.patch
+++ b/patches/llvm-8/linux/arm/0001-ARM-8860-1-VDSO-Drop-implicit-common-page-size-linke.patch
@@ -1,37 +1,38 @@
-From 7a48e7c758761495f446ddd8eea8bc30208e69e9 Mon Sep 17 00:00:00 2001
+From bb256de5a47f34814c4eddcb349c6f4963ceb3d0 Mon Sep 17 00:00:00 2001
 From: Nick Desaulniers <ndesaulniers@google.com>
-Date: Mon, 10 Dec 2018 14:31:32 -0800
-Subject: [PATCH] ARM: VDSO: Drop implicit common-page-size linker flag
+Date: Wed, 24 Apr 2019 19:37:46 +0100
+Subject: [PATCH] ARM: 8860/1: VDSO: Drop implicit common-page-size linker flag
 
 GNU linker's -z common-page-size's default value is based on the target
 architecture. arch/arm/vdso/Makefile sets it to the architecture
 default, which is implicit and redundant. Drop it.
 
 Link: https://lkml.kernel.org/r/20181206191231.192355-1-ndesaulniers@google.com
+
 Acked-by: Arnd Bergmann <arnd@arndb.de>
 Acked-by: Nathan Lynch <nathanl@linux.ibm.com>
 Suggested-by: Nathan Chancellor <natechancellor@gmail.com>
 Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
-(am from https://www.arm.linux.org.uk/developer/patches/viewpatch.php?id=8860/1)
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
 Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
 ---
  arch/arm/vdso/Makefile | 3 +--
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/arch/arm/vdso/Makefile b/arch/arm/vdso/Makefile
-index fadf554d9391..db1754438267 100644
+index 1f5ec9741e6d..ca85df247775 100644
 --- a/arch/arm/vdso/Makefile
 +++ b/arch/arm/vdso/Makefile
-@@ -11,8 +11,7 @@ ccflags-y := -fPIC -fno-common -fno-builtin -fno-stack-protector
- ccflags-y += -DDISABLE_BRANCH_PROFILING
+@@ -12,8 +12,7 @@ ccflags-y += -DDISABLE_BRANCH_PROFILING
  
- ldflags-y = -Bsymbolic --no-undefined -soname=linux-vdso.so.1 \
+ ldflags-$(CONFIG_CPU_ENDIAN_BE8) := --be8
+ ldflags-y := -Bsymbolic --no-undefined -soname=linux-vdso.so.1 \
 -	    -z max-page-size=4096 -z common-page-size=4096 \
--	    -nostdlib -shared \
-+	    -z max-page-size=4096 -nostdlib -shared \
+-	    -nostdlib -shared $(ldflags-y) \
++	    -z max-page-size=4096 -nostdlib -shared $(ldflags-y) \
  	    $(call ld-option, --hash-style=sysv) \
  	    $(call ld-option, --build-id) \
  	    -T
 -- 
-2.22.0.rc3
+2.22.0
 


### PR DESCRIPTION
Conflicts occur because of
https://git.kernel.org/torvalds/c/c5d0e49e8d8f1a23034fdf8e935afc0c8f7ae27d.

Use the patch information and resolution from Russell King's tree:

http://git.armlinux.org.uk/cgit/linux-arm.git/commit/?id=b777a981d504678d7d90e7449a3da0b2924a2a76

http://git.armlinux.org.uk/cgit/linux-arm.git/commit/?id=60577ebf7718cf233bc67dc2a0c4089348da5c6b

Fixes builds 34 to 36: https://travis-ci.com/ClangBuiltLinux/continuous-integration/builds/116515113