### PR TITLE
LD variable is not used only with arm64 anymore

### DIFF
--- a/usage.txt
+++ b/usage.txt
@@ -20,7 +20,7 @@ Environment variables:
       If no CC value is specified, the script will attempt to set CC to
       clang-9, clang-8, clang-7, then clang if they are found in PATH.
   LD:
-      If no LD value is specified, ${CROSS_COMPILE}ld is used. arm64 only.
+      If no LD value is specified, ${CROSS_COMPILE}ld is used.
   REPO:
       Nicknames for trees:
         linux (default)


### PR DESCRIPTION
`usage.txt` was not updated for a long time. This message was copied from `driver.sh` and coming back from 144150ce1111bf09726327b85ab9526d6d38cff8 and is not true anymore. Removed the misleading part.