### PR TITLE
Replace qemu -nographic option with better alternative

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -297,7 +297,7 @@ boot_qemu() {
   qemu=( timeout 2m unbuffer "${qemu}"
                              -m "${qemu_ram:=512m}"
                              "${qemu_cmdline[@]}"
-                             -nographic
+                             -display none -serial mon:stdio
                              -kernel "${kernel_image}" )
   # For arm64, we want to test booting at both EL1 and EL2
   if [[ ${ARCH} = "arm64" ]]; then


### PR DESCRIPTION
QEMU `-nographic` option is legacy and is kept only for compatibility. It does several things at once and not all of them are wanted. For example, it may clear screen when booting which is unwanted in most cases (but makes no difference with travis). Using `-display none -serial mon:stdio` ensures that the output is only added to the console.