### PR TITLE
Update buildroot to 2019.02.3 LTS

### DIFF
--- a/buildroot/rebuild.sh
+++ b/buildroot/rebuild.sh
@@ -10,7 +10,7 @@ rm -rf build
 mkdir -p build
 
 # Download latest buildroot release
-curl https://buildroot.org/downloads/buildroot-2018.08.2.tar.gz | tar -xzf - -C build --strip-components=1
+curl https://buildroot.org/downloads/buildroot-2019.02.3.tar.gz | tar -xzf - -C build --strip-components=1
 cd build || exit 1
 
 # Use the config in the parent folder


### PR DESCRIPTION
RISCV needs a newer buildroot #70 
This is probably a good chance to put this change in it's own PR and ensure there are no ci regressions.
I kept it in line continuing to use the LTS version.
See how the tests go. :)