### PR TITLE
Boot via EFI on arm64 and x86_64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.fd
 *.swp
 *.tar.gz
 .ccache

--- a/driver.sh
+++ b/driver.sh
@@ -87,6 +87,12 @@ setup_variables() {
       qemu_cmdline=( -cpu cortex-a57
                      -drive "file=images/arm64/rootfs.ext4,format=raw"
                      -append "console=ttyAMA0 root=/dev/vda" )
+      aavmf=/usr/share/AAVMF
+      if [[ -f ${aavmf}/AAVMF_CODE.fd && -f ${aavmf}/AAVMF_VARS.fd ]]; then
+        cp ${aavmf}/AAVMF_VARS.fd images/arm64
+        qemu_cmdline+=( -drive "if=pflash,format=raw,readonly,file=${aavmf}/AAVMF_CODE.fd"
+                        -drive "if=pflash,format=raw,file=images/arm64/AAVMF_VARS.fd" )
+      fi
       export CROSS_COMPILE=aarch64-linux-gnu- ;;
 
     "mipsel")
@@ -147,6 +153,12 @@ setup_variables() {
           qemu_cmdline=( -drive "file=images/x86_64/rootfs.ext4,format=raw,if=ide"
                          -append "console=ttyS0 root=/dev/sda" ) ;;
       esac
+      ovmf=/usr/share/OVMF
+      if [[ -f ${ovmf}/OVMF_CODE.fd && -f ${ovmf}/OVMF_VARS.fd ]]; then
+        cp ${ovmf}/OVMF_VARS.fd images/x86_64
+        qemu_cmdline+=( -drive "if=pflash,format=raw,readonly,file=${ovmf}/OVMF_CODE.fd"
+                        -drive "if=pflash,format=raw,file=images/x86_64/OVMF_VARS.fd" )
+      fi
       # Use KVM if the processor supports it (first part) and the KVM module is loaded (second part)
       [[ $(grep -c -E 'vmx|svm' /proc/cpuinfo) -gt 0 && $(lsmod 2>/dev/null | grep -c kvm) -gt 0 ]] && qemu_cmdline=( "${qemu_cmdline[@]}" -enable-kvm )
       image_name=bzImage

--- a/patches/llvm-all/linux/arm64/0001-arm64-efi-Move-variable-assignments-after-SECTIONS.patch
+++ b/patches/llvm-all/linux/arm64/0001-arm64-efi-Move-variable-assignments-after-SECTIONS.patch
@@ -1,0 +1,172 @@
+From f43cc4ed67f44f22754bef5bec98bf8aad3e6e8d Mon Sep 17 00:00:00 2001
+From: Kees Cook <keescook@chromium.org>
+Date: Tue, 13 Aug 2019 16:04:50 -0700
+Subject: [PATCH] arm64/efi: Move variable assignments after SECTIONS
+
+It seems that LLVM's linker does not correctly handle variable assignments
+involving section positions that are updated during the SECTIONS
+parsing. Commit aa69fb62bea1 ("arm64/efi: Mark __efistub_stext_offset as
+an absolute symbol explicitly") ran into this too, but found a different
+workaround.
+
+However, this was not enough, as other variables were also miscalculated
+which manifested as boot failures under UEFI where __efistub__end was
+not taking the correct _end value (they should be the same):
+
+$ ld.lld -EL -maarch64elf --no-undefined -X -shared \
+	-Bsymbolic -z notext -z norelro --no-apply-dynamic-relocs \
+	-o vmlinux.lld -T poc.lds --whole-archive vmlinux.o && \
+  readelf -Ws vmlinux.lld | egrep '\b(__efistub_|)_end\b'
+368272: ffff000002218000     0 NOTYPE  LOCAL  HIDDEN    38 __efistub__end
+368322: ffff000012318000     0 NOTYPE  GLOBAL DEFAULT   38 _end
+
+$ aarch64-linux-gnu-ld.bfd -EL -maarch64elf --no-undefined -X -shared \
+	-Bsymbolic -z notext -z norelro --no-apply-dynamic-relocs \
+	-o vmlinux.bfd -T poc.lds --whole-archive vmlinux.o && \
+  readelf -Ws vmlinux.bfd | egrep '\b(__efistub_|)_end\b'
+338124: ffff000012318000     0 NOTYPE  LOCAL  DEFAULT  ABS __efistub__end
+383812: ffff000012318000     0 NOTYPE  GLOBAL DEFAULT 15325 _end
+
+To work around this, all of the __efistub_-prefixed variable assignments
+need to be moved after the linker script's SECTIONS entry. As it turns
+out, this also solves the problem fixed in commit aa69fb62bea1, so those
+changes are reverted here.
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/634
+Link: https://bugs.llvm.org/show_bug.cgi?id=42990
+Acked-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>
+Signed-off-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Will Deacon <will@kernel.org>
+(am from https://git.kernel.org/arm64/c/90776dd1c427cbb4d381aa4b13338f1fb1d20f5e)
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+---
+ arch/arm64/kernel/image-vars.h  | 51 +++++++++++++++++++++++++++++++++
+ arch/arm64/kernel/image.h       | 42 ---------------------------
+ arch/arm64/kernel/vmlinux.lds.S |  2 ++
+ 3 files changed, 53 insertions(+), 42 deletions(-)
+ create mode 100644 arch/arm64/kernel/image-vars.h
+
+diff --git a/arch/arm64/kernel/image-vars.h b/arch/arm64/kernel/image-vars.h
+new file mode 100644
+index 000000000000..25a2a9b479c2
+--- /dev/null
++++ b/arch/arm64/kernel/image-vars.h
+@@ -0,0 +1,51 @@
++/* SPDX-License-Identifier: GPL-2.0-only */
++/*
++ * Linker script variables to be set after section resolution, as
++ * ld.lld does not like variables assigned before SECTIONS is processed.
++ */
++#ifndef __ARM64_KERNEL_IMAGE_VARS_H
++#define __ARM64_KERNEL_IMAGE_VARS_H
++
++#ifndef LINKER_SCRIPT
++#error This file should only be included in vmlinux.lds.S
++#endif
++
++#ifdef CONFIG_EFI
++
++__efistub_stext_offset = stext - _text;
++
++/*
++ * The EFI stub has its own symbol namespace prefixed by __efistub_, to
++ * isolate it from the kernel proper. The following symbols are legally
++ * accessed by the stub, so provide some aliases to make them accessible.
++ * Only include data symbols here, or text symbols of functions that are
++ * guaranteed to be safe when executed at another offset than they were
++ * linked at. The routines below are all implemented in assembler in a
++ * position independent manner
++ */
++__efistub_memcmp		= __pi_memcmp;
++__efistub_memchr		= __pi_memchr;
++__efistub_memcpy		= __pi_memcpy;
++__efistub_memmove		= __pi_memmove;
++__efistub_memset		= __pi_memset;
++__efistub_strlen		= __pi_strlen;
++__efistub_strnlen		= __pi_strnlen;
++__efistub_strcmp		= __pi_strcmp;
++__efistub_strncmp		= __pi_strncmp;
++__efistub_strrchr		= __pi_strrchr;
++__efistub___flush_dcache_area	= __pi___flush_dcache_area;
++
++#ifdef CONFIG_KASAN
++__efistub___memcpy		= __pi_memcpy;
++__efistub___memmove		= __pi_memmove;
++__efistub___memset		= __pi_memset;
++#endif
++
++__efistub__text			= _text;
++__efistub__end			= _end;
++__efistub__edata		= _edata;
++__efistub_screen_info		= screen_info;
++
++#endif
++
++#endif /* __ARM64_KERNEL_IMAGE_VARS_H */
+diff --git a/arch/arm64/kernel/image.h b/arch/arm64/kernel/image.h
+index 2b85c0d6fa3d..c7d38c660372 100644
+--- a/arch/arm64/kernel/image.h
++++ b/arch/arm64/kernel/image.h
+@@ -65,46 +65,4 @@
+ 	DEFINE_IMAGE_LE64(_kernel_offset_le, TEXT_OFFSET);	\
+ 	DEFINE_IMAGE_LE64(_kernel_flags_le, __HEAD_FLAGS);
+ 
+-#ifdef CONFIG_EFI
+-
+-/*
+- * Use ABSOLUTE() to avoid ld.lld treating this as a relative symbol:
+- * https://github.com/ClangBuiltLinux/linux/issues/561
+- */
+-__efistub_stext_offset = ABSOLUTE(stext - _text);
+-
+-/*
+- * The EFI stub has its own symbol namespace prefixed by __efistub_, to
+- * isolate it from the kernel proper. The following symbols are legally
+- * accessed by the stub, so provide some aliases to make them accessible.
+- * Only include data symbols here, or text symbols of functions that are
+- * guaranteed to be safe when executed at another offset than they were
+- * linked at. The routines below are all implemented in assembler in a
+- * position independent manner
+- */
+-__efistub_memcmp		= __pi_memcmp;
+-__efistub_memchr		= __pi_memchr;
+-__efistub_memcpy		= __pi_memcpy;
+-__efistub_memmove		= __pi_memmove;
+-__efistub_memset		= __pi_memset;
+-__efistub_strlen		= __pi_strlen;
+-__efistub_strnlen		= __pi_strnlen;
+-__efistub_strcmp		= __pi_strcmp;
+-__efistub_strncmp		= __pi_strncmp;
+-__efistub_strrchr		= __pi_strrchr;
+-__efistub___flush_dcache_area	= __pi___flush_dcache_area;
+-
+-#ifdef CONFIG_KASAN
+-__efistub___memcpy		= __pi_memcpy;
+-__efistub___memmove		= __pi_memmove;
+-__efistub___memset		= __pi_memset;
+-#endif
+-
+-__efistub__text			= _text;
+-__efistub__end			= _end;
+-__efistub__edata		= _edata;
+-__efistub_screen_info		= screen_info;
+-
+-#endif
+-
+ #endif /* __ARM64_KERNEL_IMAGE_H */
+diff --git a/arch/arm64/kernel/vmlinux.lds.S b/arch/arm64/kernel/vmlinux.lds.S
+index 7fa008374907..803b24d2464a 100644
+--- a/arch/arm64/kernel/vmlinux.lds.S
++++ b/arch/arm64/kernel/vmlinux.lds.S
+@@ -245,6 +245,8 @@ SECTIONS
+ 	HEAD_SYMBOLS
+ }
+ 
++#include "image-vars.h"
++
+ /*
+  * The HYP init code and ID map text can't be longer than a page each,
+  * and should not cross a page boundary.
+-- 
+2.23.0.rc2
+


### PR DESCRIPTION
This is currently a WIP but I wanted to push what I had for initial review before I left for work.

@kees noticed that booting via EFI was broken on arm64 because of an ld.lld change: https://github.com/ClangBuiltLinux/linux/issues/634

This will allow us to catch regressions like this in the future.

To work properly, the `ovmf` and `qemu-efi-aarch64` packages need to be installed, which will be done in a separate pull request to the Docker image repo.

As it stands now, there are three distinct issues:

1. x86_64 panics on init because `/dev/sda` is no longer available:

```
[   13.227390] VFS: Cannot open root device "sda" or unknown-block(0,0): error -6
[   13.227919] Please append a correct "root=" boot option; here are the available partitions:
[   13.229050] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)
[   13.230040] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 5.3.0-rc4+ #1
[   13.230565] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 0.0.0 02/06/2015
[   13.231331] Call Trace:
[   13.232041]  dump_stack+0xa3/0x10b
[   13.232465]  panic+0xfd/0x2ff
[   13.232734]  ? klist_next+0x84/0xb0
[   13.233104]  mount_block_root+0x12e/0x1bd
[   13.233462]  ? gen6_set_rps+0xa0/0x1d0
[   13.233819]  ? kernel_init+0x6/0x2d0
[   13.234134]  prepare_namespace+0x17c/0x181
[   13.234474]  kernel_init_freeable+0x195/0x1be
[   13.234865]  ? rest_init+0x1e0/0x1e0
[   13.235204]  kernel_init+0x6/0x2d0
[   13.235491]  ? rest_init+0x1e0/0x1e0
[   13.235819]  ret_from_fork+0x3a/0x50
[   13.237306] Kernel Offset: 0x26a00000 from 0xffffffff81000000 (relocation range: 0xffffffff80000000-0xffffffffbfffffff)
[   13.238690] ---[ end Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0) ]---
```

Looks like `-bios` might be an option instead:

```
diff --git a/driver.sh b/driver.sh
index d86a718..33d381b 100755
--- a/driver.sh
+++ b/driver.sh
@@ -153,12 +153,8 @@ setup_variables() {
           qemu_cmdline=( -drive "file=images/x86_64/rootfs.ext4,format=raw,if=ide"
                          -append "console=ttyS0 root=/dev/sda" ) ;;
       esac
-      ovmf=/usr/share/OVMF
-      if [[ -f ${ovmf}/OVMF_CODE.fd && -f ${ovmf}/OVMF_VARS.fd ]]; then
-        cp ${ovmf}/OVMF_VARS.fd images/x86_64
-        qemu_cmdline+=( -drive "if=pflash,format=raw,readonly,file=${ovmf}/OVMF_CODE.fd"
-                        -drive "if=pflash,format=raw,file=images/x86_64/OVMF_VARS.fd" )
-      fi
+      ovmf=/usr/share/qemu/OVMF.fd
+      [[ -f ${ovmf} ]] && qemu_cmdline+=( -bios ${ovmf} )
       # Use KVM if the processor supports it (first part) and the KVM module is loaded (second part)
       [[ $(grep -c -E 'vmx|svm' /proc/cpuinfo) -gt 0 && $(lsmod 2>/dev/null | grep -c kvm) -gt 0 ]] && qemu_cmdline=( "${qemu_cmdline[@]}" -enable-kvm )
       image_name=bzImage
```

2. arm64 panics on init because `/dev/vda` is no longer available:

```
VFS: Cannot open root device "vda" or unknown-block(0,0): error -6
Please append a correct "root=" boot option; here are the available partitions:
Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)
CPU: 0 PID: 1 Comm: swapper/0 Not tainted 4.4.189+ #12
Hardware name: QEMU QEMU Virtual Machine, BIOS 0.0.0 02/06/2015
Call trace:
[<ffffffc000089ecc>] dump_backtrace+0x0/0x144
[<ffffffc000089ec4>] show_stack+0x14/0x1c
[<ffffffc00037b2e8>] dump_stack+0xf8/0x148
[<ffffffc0000b69d4>] panic+0xd8/0x22c
[<ffffffc0009f8054>] mount_block_root+0x1d8/0x2b0
[<ffffffc0009f81d0>] mount_root+0xa4/0x19c
[<ffffffc0009f83e4>] prepare_namespace+0x11c/0x190
[<ffffffc0009f7d40>] kernel_init_freeable+0x1d4/0x1f8
[<ffffffc0007471fc>] kernel_init+0x10/0x1d4
[<ffffffc000085e50>] ret_from_fork+0x10/0x40
---[ end Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)
```

Have not begun to triage this at all.

3. kernel/common builds all appear to boot but hang when shutting down so the VM doesn't exit cleanly:

```
[   11.292195] Run /init as init process
Starting syslogd: OK
Starting klogd: OK
Initializing random number generator... [   11.881486] random: dd: uninitialized urandom read (512 bytes read)
done.
Starting network: [   12.264558] ip (982) used greatest stack depth: 12320 bytes left
OK
Linux version 4.19.66-gd8837b869 (driver@clangbuiltlinux) (clang version 9.0.0-svn366197-1~exp1+0~20190716095603.167~1.gbp7d3830 (trunk)) #7 SMP PREEMPT Thu Jan 1 00:00:00 UTC 1970
Linux version 4.19.66-gd8837b869 (driver@clangbuiltlinux) (clang version 9.0.0-svn366197-1~exp1+0~20190716095603.167~1.gbp7d3830 (trunk)) #7 SMP PREEMPT Thu Jan 1 00:00:00 UTC 1970
Stopping network: OK
Saving random seed... [   12.888645] random: dd: uninitialized urandom read (512 bytes read)
done.
Stopping klogd: OK
Stopping syslogd: OK
umount: devtmpfs busy - remounted read-only
umount: can't unmount /: Invalid argument
The system is going down NOW!
Sent SIGTERM to all processes
Sent SIGKILL to all processes
Requesting system poweroff
[   15.266490] reboot: System halted
root@097b229733d2:/ci2# echo $?
124
```

I'll try to get this all cleaned up so we can actually run this on Travis and see everything a bit more clearly.