### PR TITLE
Change android common cuttlefish configs to gki_defconfig

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -79,7 +79,7 @@ setup_variables() {
 
     "arm64")
       case ${REPO} in
-        common-*) config=cuttlefish_defconfig ;;
+        common-*) config=gki_defconfig ;;
         *) config=defconfig ;;
       esac
       image_name=Image.gz
@@ -139,7 +139,7 @@ setup_variables() {
     "x86_64")
       case ${REPO} in
         common-*)
-          config=x86_64_cuttlefish_defconfig
+          config=gki_defconfig
           qemu_cmdline=( -append "console=ttyS0"
                          -initrd "images/x86_64/rootfs.cpio" ) ;;
         *)


### PR DESCRIPTION
Nathan noticed that they were removed:
https://android.googlesource.com/kernel/common/+/3f0d9e29849d2ab72600269041fce18ff1b0b99a

Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>