### PR TITLE
driver: Use gki_defconfig for android-4.19 and newer

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -79,7 +79,11 @@ setup_variables() {
 
     "arm64")
       case ${REPO} in
-        common-*) config=cuttlefish_defconfig ;;
+        common-*)
+          case ${branch} in
+            *4.9|*4.14) config=cuttlefish_defconfig ;;
+            *) config=gki_defconfig ;;
+          esac ;;
         *) config=defconfig ;;
       esac
       image_name=Image.gz
@@ -139,7 +143,10 @@ setup_variables() {
     "x86_64")
       case ${REPO} in
         common-*)
-          config=x86_64_cuttlefish_defconfig
+          case ${branch} in
+            *4.9|*4.14) config=x86_64_cuttlefish_defconfig ;;
+            *) config=gki_defconfig ;;
+          esac
           qemu_cmdline=( -append "console=ttyS0"
                          -initrd "images/x86_64/rootfs.cpio" ) ;;
         *)


### PR DESCRIPTION
Needed due to https://github.com/aosp-mirror/kernel_common/commit/3f0d9e29849d2ab72600269041fce18ff1b0b99a.

Fixes the following failures:

https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/228142092

https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/228142095

Presubmit:

https://travis-ci.com/nathanchance/continuous-integration/builds/124606638