### PR TITLE
travis: Enable 32-bit little endian MIPS on linux-next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ matrix:
     - name: "ARCH=arm64 LD=ld.lld REPO=linux-next"
       env: ARCH=arm64 LD=ld.lld-10 REPO=linux-next
       if: type = cron
+    - name: "ARCH=mipsel REPO=linux-next"
+      env: ARCH=mipsel REPO=linux-next
+      if: type = cron
     - name: "ARCH=ppc32 REPO=linux-next"
       env: ARCH=ppc32 REPO=linux-next
       if: type = cron


### PR DESCRIPTION
All of the necessary patches have been applied to their respective trees
and they are all available in linux-next.

This requires a bump in the Docker image first: https://github.com/ClangBuiltLinux/dockerimage/pull/35

Presubmit will be run once that change has been merged.