### PR TITLE
travis: Bump LLVM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,17 @@ matrix:
     - name: "ARCH=arm32_v6"
       env: ARCH=arm32_v6
     - name: "ARCH=arm32_v7 LD=ld.lld"
-      env: ARCH=arm32_v7 LD=ld.lld-9
+      env: ARCH=arm32_v7 LD=ld.lld-10
     - name: "ARCH=arm64 LD=ld.lld"
-      env: ARCH=arm64 LD=ld.lld-9
+      env: ARCH=arm64 LD=ld.lld-10
     - name: "ARCH=ppc32"
       env: ARCH=ppc32
     - name: "ARCH=ppc64"
       env: ARCH=ppc64
     - name: "ARCH=ppc64le LD=ld.lld"
-      env: ARCH=ppc64le LD=ld.lld-9
+      env: ARCH=ppc64le LD=ld.lld-10
     - name: "ARCH=x86_64 LD=ld.lld"
-      env: ARCH=x86_64 LD=ld.lld-9
+      env: ARCH=x86_64 LD=ld.lld-10
     # linux (cron only)
     #
     # linux-next (cron only)
@@ -28,10 +28,10 @@ matrix:
       env: ARCH=arm32_v6 REPO=linux-next
       if: type = cron
     - name: "ARCH=arm32_v7 LD=ld.lld REPO=linux-next"
-      env: ARCH=arm32_v7 LD=ld.lld-9 REPO=linux-next
+      env: ARCH=arm32_v7 LD=ld.lld-10 REPO=linux-next
       if: type = cron
     - name: "ARCH=arm64 LD=ld.lld REPO=linux-next"
-      env: ARCH=arm64 LD=ld.lld-9 REPO=linux-next
+      env: ARCH=arm64 LD=ld.lld-10 REPO=linux-next
       if: type = cron
     - name: "ARCH=ppc32 REPO=linux-next"
       env: ARCH=ppc32 REPO=linux-next
@@ -40,10 +40,10 @@ matrix:
       env: ARCH=ppc64 REPO=linux-next
       if: type = cron
     - name: "ARCH=ppc64le LD=ld.lld REPO=linux-next"
-      env: ARCH=ppc64le LD=ld.lld-9 REPO=linux-next
+      env: ARCH=ppc64le LD=ld.lld-10 REPO=linux-next
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=linux-next"
-      env: ARCH=x86_64 LD=ld.lld-9 REPO=linux-next
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=linux-next
       if: type = cron
     # stable
     - name: "ARCH=arm32_v7 REPO=4.19"
@@ -56,7 +56,7 @@ matrix:
       env: ARCH=ppc64le REPO=4.19
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=4.19"
-      env: ARCH=x86_64 LD=ld.lld-9 REPO=4.19
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=4.19
       if: type = cron
     - name: "ARCH=arm32_v7 REPO=4.14"
       env: ARCH=arm32_v7 REPO=4.14
@@ -68,7 +68,7 @@ matrix:
       env: ARCH=ppc64le REPO=4.14
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=4.14"
-      env: ARCH=x86_64 LD=ld.lld-9 REPO=4.14
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=4.14
       if: type = cron
     - name: "ARCH=arm32_v7 REPO=4.9"
       env: ARCH=arm32_v7 REPO=4.9
@@ -77,13 +77,13 @@ matrix:
       env: ARCH=arm64 REPO=4.9
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=4.9"
-      env: ARCH=x86_64 LD=ld.lld-9 REPO=4.9
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=4.9
       if: type = cron
     - name: "ARCH=arm64 REPO=4.4"
       env: ARCH=arm64 REPO=4.4
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=4.4"
-      env: ARCH=x86_64 LD=ld.lld-9 REPO=4.4
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=4.4
       if: type = cron
     # kernel/common
     - name: "ARCH=arm64 REPO=common-4.9"
@@ -96,38 +96,38 @@ matrix:
       env: ARCH=arm64 REPO=common-4.19
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=common-4.9"
-      env: ARCH=x86_64 LD=ld.lld-9 REPO=common-4.9
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=common-4.9
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=common-4.14"
-      env: ARCH=x86_64 LD=ld.lld-9 REPO=common-4.14
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=common-4.14
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=common-4.19"
-      env: ARCH=x86_64 LD=ld.lld-9 REPO=common-4.19
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=common-4.19
       if: type = cron
     # linux with stable LLVM/Clang
-    - name: "ARCH=arm32_v5 LLVM_VERSION=8"
-      env: ARCH=arm32_v5 LLVM_VERSION=8
+    - name: "ARCH=arm32_v5 LLVM_VERSION=9"
+      env: ARCH=arm32_v5 LLVM_VERSION=9
       if: type = cron
-    - name: "ARCH=arm32_v6 LLVM_VERSION=8"
-      env: ARCH=arm32_v6 LLVM_VERSION=8
+    - name: "ARCH=arm32_v6 LLVM_VERSION=9"
+      env: ARCH=arm32_v6 LLVM_VERSION=9
       if: type = cron
-    - name: "ARCH=arm32_v7 LD=ld.lld LLVM_VERSION=8"
-      env: ARCH=arm32_v7 LD=ld.lld-8 LLVM_VERSION=8
+    - name: "ARCH=arm32_v7 LD=ld.lld LLVM_VERSION=9"
+      env: ARCH=arm32_v7 LD=ld.lld-9 LLVM_VERSION=9
       if: type = cron
-    - name: "ARCH=arm64 LLVM_VERSION=8"
-      env: ARCH=arm64 LLVM_VERSION=8
+    - name: "ARCH=arm64 LLVM_VERSION=9"
+      env: ARCH=arm64 LLVM_VERSION=9
       if: type = cron
-    - name: "ARCH=ppc32 LLVM_VERSION=8"
-      env: ARCH=ppc32 LLVM_VERSION=8
+    - name: "ARCH=ppc32 LLVM_VERSION=9"
+      env: ARCH=ppc32 LLVM_VERSION=9
       if: type = cron
-    - name: "ARCH=ppc64 REPO=linux-next LLVM_VERSION=8"
-      env: ARCH=ppc64 REPO=linux-next LLVM_VERSION=8
+    - name: "ARCH=ppc64 REPO=linux-next LLVM_VERSION=9"
+      env: ARCH=ppc64 REPO=linux-next LLVM_VERSION=9
       if: type = cron
-    - name: "ARCH=ppc64le LLVM_VERSION=8"
-      env: ARCH=ppc64le LLVM_VERSION=8
+    - name: "ARCH=ppc64le LLVM_VERSION=9"
+      env: ARCH=ppc64le LLVM_VERSION=9
       if: type = cron
-    - name: "ARCH=x86_64 LLVM_VERSION=8"
-      env: ARCH=x86_64 LLVM_VERSION=8
+    - name: "ARCH=x86_64 LLVM_VERSION=9"
+      env: ARCH=x86_64 LLVM_VERSION=9
       if: type = cron
 compiler: gcc
 os: linux
@@ -147,7 +147,7 @@ script:
         --rm \
         --workdir /travis \
         --volume ${TRAVIS_BUILD_DIR}:/travis \
-        clangbuiltlinux/debian:llvm${LLVM_VERSION:-9}-latest /bin/bash -c './env-setup.sh && ./driver.sh && ccache -s'
+        clangbuiltlinux/debian:llvm${LLVM_VERSION:-10}-latest /bin/bash -c './env-setup.sh && ./driver.sh && ccache -s'
 after_script:
   - sleep 1
 notifications:


### PR DESCRIPTION
Same logic as https://github.com/ClangBuiltLinux/dockerimage/pull/36.

TODO: Try to simplify this logic by making the versioning automatic in `driver.sh` if running a Travis build (Travis specific variables set for example).