### PR TITLE
travis: Add MIPS 32-bit little endian to mainline targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       env: ARCH=arm32_v7 LD=ld.lld-10
     - name: "ARCH=arm64 LD=ld.lld"
       env: ARCH=arm64 LD=ld.lld-10
+    - name: "ARCH=mipsel"
+      env: ARCH=mipsel
     - name: "ARCH=ppc32"
       env: ARCH=ppc32
     - name: "ARCH=ppc64"


### PR DESCRIPTION
Now that all patches have been merged.

Presubmit: https://travis-ci.com/nathanchance/continuous-integration/jobs/238347601