### PR TITLE
rename android common branches that were moved.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,23 +91,23 @@ matrix:
       env: ARCH=x86_64 LD=ld.lld-10 REPO=4.4
       if: type = cron
     # kernel/common
-    - name: "ARCH=arm64 REPO=common-4.9"
-      env: ARCH=arm64 REPO=common-4.9
+    - name: "ARCH=arm64 REPO=android-4.9-q"
+      env: ARCH=arm64 REPO=android-4.9-q
       if: type = cron
-    - name: "ARCH=arm64 REPO=common-4.14"
-      env: ARCH=arm64 REPO=common-4.14
+    - name: "ARCH=arm64 REPO=android-4.14"
+      env: ARCH=arm64 REPO=android-4.14
       if: type = cron
-    - name: "ARCH=arm64 REPO=common-4.19"
-      env: ARCH=arm64 REPO=common-4.19
+    - name: "ARCH=arm64 REPO=android-4.19"
+      env: ARCH=arm64 REPO=android-4.19
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=common-4.9"
-      env: ARCH=x86_64 LD=ld.lld-10 REPO=common-4.9
+    - name: "ARCH=x86_64 LD=ld.lld REPO=android-4.9-q"
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=android-4.9-q
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=common-4.14"
-      env: ARCH=x86_64 LD=ld.lld-10 REPO=common-4.14
+    - name: "ARCH=x86_64 LD=ld.lld REPO=android-4.14"
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=android-4.14
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=common-4.19"
-      env: ARCH=x86_64 LD=ld.lld-10 REPO=common-4.19
+    - name: "ARCH=x86_64 LD=ld.lld REPO=android-4.19"
+      env: ARCH=x86_64 LD=ld.lld-10 REPO=android-4.19
       if: type = cron
     # linux with stable LLVM/Clang
     - name: "ARCH=arm32_v5 LLVM_VERSION=9"

--- a/driver.sh
+++ b/driver.sh
@@ -23,9 +23,9 @@ setup_variables() {
 
   # torvalds/linux is the default repo if nothing is specified
   case ${REPO:=linux} in
-    "common-"*)
-      branch=android-${REPO##*-}
+    "android-"*)
       tree=common
+      branch=${REPO}
       url=https://android.googlesource.com/kernel/${tree} ;;
     "linux")
       owner=torvalds
@@ -79,9 +79,9 @@ setup_variables() {
 
     "arm64")
       case ${REPO} in
-        common-*)
+        android-*)
           case ${branch} in
-            *4.9|*4.14) config=cuttlefish_defconfig ;;
+            *4.9-q|*4.14) config=cuttlefish_defconfig ;;
             *) config=gki_defconfig ;;
           esac ;;
         *) config=defconfig ;;
@@ -142,9 +142,9 @@ setup_variables() {
 
     "x86_64")
       case ${REPO} in
-        common-*)
+        android-*)
           case ${branch} in
-            *4.9|*4.14) config=x86_64_cuttlefish_defconfig ;;
+            *4.9-q|*4.14) config=x86_64_cuttlefish_defconfig ;;
             *) config=gki_defconfig ;;
           esac
           qemu_cmdline=( -append "console=ttyS0"


### PR DESCRIPTION
android-4.9 branch was moved to remotes/origin/deprecated/android-4.9.
The branch android-4.9-q is the final branch. Android common kernel team
has recently changed their branching strategy.  It's recommended to

$ git fetch --prune

To see what branches are still alive.

Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>