### PR TITLE
link more arm64 stable with LLD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ matrix:
     - name: "ARCH=arm32_v7 REPO=4.19"
       env: ARCH=arm32_v7 REPO=4.19
       if: type = cron
-    - name: "ARCH=arm64 REPO=4.19"
-      env: ARCH=arm64 REPO=4.19
+    - name: "ARCH=arm64 LD=ld.lld REPO=4.19"
+      env: ARCH=arm64 LD=ld.lld-10 REPO=4.19
       if: type = cron
     - name: "ARCH=ppc64le REPO=4.19"
       env: ARCH=ppc64le REPO=4.19
@@ -66,8 +66,8 @@ matrix:
     - name: "ARCH=arm32_v7 REPO=4.14"
       env: ARCH=arm32_v7 REPO=4.14
       if: type = cron
-    - name: "ARCH=arm64 REPO=4.14"
-      env: ARCH=arm64 REPO=4.14
+    - name: "ARCH=arm64 LD=ld.lld REPO=4.14"
+      env: ARCH=arm64 LD=ld.lld-10 REPO=4.14
       if: type = cron
     - name: "ARCH=ppc64le REPO=4.14"
       env: ARCH=ppc64le REPO=4.14


### PR DESCRIPTION
Older stable is failing seemingly related to incremental linking being
removed in 4.17-rc1:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f49821ee32b76b1a356fab17316eb62430182ecf
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5e18f0290f2eccb0f64e87fbfca6395f11985b4b