### PR TITLE
enable llvm-size by default for all arch's

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -5,7 +5,7 @@ set -eu
 setup_variables() {
   while [[ ${#} -ge 1 ]]; do
     case ${1} in
-      "AR="*|"ARCH="*|"CC="*|"LD="*|"NM"=*|"OBJDUMP"=*|"REPO="*) export "${1?}" ;;
+      "AR="*|"ARCH="*|"CC="*|"LD="*|"NM"=*|"OBJDUMP"=*|"OBJSIZE"=*|"REPO="*) export "${1?}" ;;
       "-c"|"--clean") cleanup=true ;;
       "-j"|"--jobs") shift; jobs=$1 ;;
       "-j"*) jobs=${1/-j} ;;
@@ -238,6 +238,12 @@ check_dependencies() {
       command -v ${OBJDUMP} 2>/dev/null && break
     done
   fi
+
+  if [[ -z "${OBJSIZE:-}" ]]; then
+    for OBJSIZE in $(gen_bin_list llvm-size) llvm-size "${CROSS_COMPILE:-}"size; do
+      command -v ${OBJSIZE} 2>/dev/null && break
+    done
+  fi
 }
 
 # Optimistically check to see that the user has a llvm-ar
@@ -276,6 +282,7 @@ mako_reactor() {
        LD="${LD}" \
        NM="${NM}" \
        OBJDUMP="${OBJDUMP}" \
+       OBJSIZE="${OBJSIZE}" \
        "${@}"
 }
 

--- a/usage.txt
+++ b/usage.txt
@@ -34,6 +34,11 @@ Environment variables:
         common-4.14
         common-4.9
         common-4.4
+  OBJSIZE:
+      If no OBJSIZE value is specified, the script will attempt to set OBJSIZE
+      to llvm-size-10 llvm-size-9, llvm-size-8, llvm-size-7, llvm-size, then
+      ${CROSS_COMPILE}size if they are found in PATH.
+
 
 Optional parameters:
   -c | --clean:


### PR DESCRIPTION
though it's only used on s390