### PR TITLE
selectively re-enable llvm-objcopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ matrix:
       env: ARCH=arm32_v6
     - name: "ARCH=arm32_v7 LD=ld.lld"
       env: ARCH=arm32_v7 LD=ld.lld-10
-    - name: "ARCH=arm64 LD=ld.lld"
-      env: ARCH=arm64 LD=ld.lld-10
+    - name: "ARCH=arm64 OBJCOPY=llvm-objcopy LD=ld.lld"
+      env: ARCH=arm64 OBJCOPY=llvm-objcopy-10 LD=ld.lld-10
     - name: "ARCH=mipsel"
       env: ARCH=mipsel
     - name: "ARCH=ppc32"
@@ -32,8 +32,8 @@ matrix:
     - name: "ARCH=arm32_v7 LD=ld.lld REPO=linux-next"
       env: ARCH=arm32_v7 LD=ld.lld-10 REPO=linux-next
       if: type = cron
-    - name: "ARCH=arm64 LD=ld.lld REPO=linux-next"
-      env: ARCH=arm64 LD=ld.lld-10 REPO=linux-next
+    - name: "ARCH=arm64 OBJCOPY=llvm-objcopy LD=ld.lld REPO=linux-next"
+      env: ARCH=arm64 OBJCOPY=llvm-objcopy-10 LD=ld.lld-10 REPO=linux-next
       if: type = cron
     - name: "ARCH=mipsel REPO=linux-next"
       env: ARCH=mipsel REPO=linux-next
@@ -54,8 +54,8 @@ matrix:
     - name: "ARCH=arm32_v7 REPO=4.19"
       env: ARCH=arm32_v7 REPO=4.19
       if: type = cron
-    - name: "ARCH=arm64 REPO=4.19"
-      env: ARCH=arm64 REPO=4.19
+    - name: "ARCH=arm64 OBJCOPY=llvm-objcopy REPO=4.19"
+      env: ARCH=arm64 OBJCOPY=llvm-objcopy-10 REPO=4.19
       if: type = cron
     - name: "ARCH=ppc64le REPO=4.19"
       env: ARCH=ppc64le REPO=4.19
@@ -66,8 +66,8 @@ matrix:
     - name: "ARCH=arm32_v7 REPO=4.14"
       env: ARCH=arm32_v7 REPO=4.14
       if: type = cron
-    - name: "ARCH=arm64 REPO=4.14"
-      env: ARCH=arm64 REPO=4.14
+    - name: "ARCH=arm64 OBJCOPY=llvm-objcopy REPO=4.14"
+      env: ARCH=arm64 OBJCOPY=llvm-objcopy-10 REPO=4.14
       if: type = cron
     - name: "ARCH=ppc64le REPO=4.14"
       env: ARCH=ppc64le REPO=4.14
@@ -78,8 +78,8 @@ matrix:
     - name: "ARCH=arm32_v7 REPO=4.9"
       env: ARCH=arm32_v7 REPO=4.9
       if: type = cron
-    - name: "ARCH=arm64 REPO=4.9"
-      env: ARCH=arm64 REPO=4.9
+    - name: "ARCH=arm64 OBJCOPY=llvm-objcopy REPO=4.9"
+      env: ARCH=arm64 OBJCOPY=llvm-objcopy-10 REPO=4.9
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=4.9"
       env: ARCH=x86_64 LD=ld.lld-10 REPO=4.9

--- a/driver.sh
+++ b/driver.sh
@@ -5,7 +5,7 @@ set -eu
 setup_variables() {
   while [[ ${#} -ge 1 ]]; do
     case ${1} in
-      "AR="*|"ARCH="*|"CC="*|"LD="*|"NM"=*|"OBJDUMP"=*|"REPO="*) export "${1?}" ;;
+      "AR="*|"ARCH="*|"CC="*|"LD="*|"NM"=*|"OBJCOPY"=*|"OBJDUMP"=*|"REPO="*) export "${1?}" ;;
       "-c"|"--clean") cleanup=true ;;
       "-j"|"--jobs") shift; jobs=$1 ;;
       "-j"*) jobs=${1/-j} ;;
@@ -191,11 +191,12 @@ check_dependencies() {
   # Check for LD, CC, and AR environmental variables
   # and print the version string of each. If CC and AR
   # don't exist, try to find them.
-  # lld isn't ready for all architectures so it's just
-  # simpler to fall back to GNU ld when LD isn't specified
+  # lld and objcopy aren't ready for all architectures so it's just
+  # simpler to fall back to GNU ld/objcopy when LD/OBJCOPY aren't specified
   # to avoid architecture specific selection logic.
 
   "${LD:="${CROSS_COMPILE:-}"ld}" --version
+  "${OBJCOPY:="${CROSS_COMPILE:-}"objcopy}" --version
 
   if [[ -z "${CC:-}" ]]; then
     for CC in $(gen_bin_list clang) clang; do
@@ -275,6 +276,7 @@ mako_reactor() {
        KCFLAGS="-Wno-implicit-fallthrough" \
        LD="${LD}" \
        NM="${NM}" \
+       OBJCOPY="${OBJCOPY}" \
        OBJDUMP="${OBJDUMP}" \
        "${@}"
 }

--- a/usage.txt
+++ b/usage.txt
@@ -22,6 +22,8 @@ Environment variables:
       in PATH.
   LD:
       If no LD value is specified, ${CROSS_COMPILE}ld is used.
+  OBJCOPY:
+      If no OBJCOPY value is specified, ${CROSS_COMPILE}objcopy is used.
   REPO:
       Nicknames for trees:
         linux (default)


### PR DESCRIPTION
just for arm64, back to LTS 4.9.

4.4 is still broken:
https://github.com/ClangBuiltLinux/continuous-integration/issues/183#issuecomment-506861074

Previously reverted in 684262f304e3f840a95eeeaef71c95a52f44fa3f

https://github.com/ClangBuiltLinux/linux/issues/480
https://github.com/ClangBuiltLinux/continuous-integration/issues/164