### PR TITLE
driver: Fix arm32_v6 flakiness

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -349,11 +349,14 @@ boot_qemu() {
   fi
 
   test -e ${kernel_image}
-  qemu=( timeout 2m unbuffer "${qemu}"
-                             -m "${qemu_ram:=512m}"
-                             "${qemu_cmdline[@]}"
-                             -display none -serial mon:stdio
-                             -kernel "${kernel_image}" )
+  qemu=( timeout 2m
+         unbuffer
+         "${qemu}"
+         -m "${qemu_ram:=512m}"
+         "${qemu_cmdline[@]}"
+         -display none
+         -serial mon:stdio
+         -kernel "${kernel_image}" )
   # For arm64, we want to test booting at both EL1 and EL2
   if [[ ${ARCH} = "arm64" ]]; then
     "${qemu[@]}" -machine virt

--- a/driver.sh
+++ b/driver.sh
@@ -57,6 +57,7 @@ setup_variables() {
     "arm32_v6")
       config=aspeed_g5_defconfig
       image_name=zImage
+      timeout=4 # This architecture needs a bit of a longer timeout due to some flakiness on Travis
       qemu="qemu-system-arm"
       qemu_cmdline=( -machine romulus-bmc
                      -no-reboot
@@ -349,7 +350,7 @@ boot_qemu() {
   fi
 
   test -e ${kernel_image}
-  qemu=( timeout 2m
+  qemu=( timeout "${timeout:-2}"m
          unbuffer
          "${qemu}"
          -m "${qemu_ram:=512m}"


### PR DESCRIPTION
This build has been flaky since the 5.4 merge window it seems. I cannot
reproduce it locally so I believe it has something to do with Travis.
Increase the timeout to 4 minutes to make absolutely sure that the boot
has failed, rather than just being very long.

Presubmit: https://travis-ci.com/nathanchance/continuous-integration/builds/130365032