### PR TITLE
patches: ppc64: Add -ffreestanding patch to avoid bcmp error

### DIFF
--- a/patches/llvm-all/linux-next/ppc64/0001-powerpc-prom_init-Use-ffreestanding-to-avoid-a-refer.patch
+++ b/patches/llvm-all/linux-next/ppc64/0001-powerpc-prom_init-Use-ffreestanding-to-avoid-a-refer.patch
@@ -1,0 +1,49 @@
+From 1b98a48e312ac0be1746df53729fbb308a0c1ada Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <natechancellor@gmail.com>
+Date: Sun, 13 Oct 2019 19:51:01 -0700
+Subject: [PATCH] powerpc/prom_init: Use -ffreestanding to avoid a reference to
+ bcmp
+
+r374662 gives LLVM the ability to convert certain loops into a reference
+to bcmp as an optimization; this breaks prom_init_check.sh:
+
+  CALL    arch/powerpc/kernel/prom_init_check.sh
+Error: External symbol 'bcmp' referenced from prom_init.c
+make[2]: *** [arch/powerpc/kernel/Makefile:196: prom_init_check] Error 1
+
+bcmp is defined in lib/string.c as a wrapper for memcmp so this could be
+added to the whitelist. However, commit 450e7dd4001f ("powerpc/prom_init:
+don't use string functions from lib/") copied memcmp as prom_memcmp to
+avoid KASAN instrumentation so having bcmp be resolved to regular memcmp
+would break that assumption. Furthermore, because the compiler is the
+one that inserted bcmp, we cannot provide something like prom_bcmp.
+
+To prevent LLVM from being clever with optimizations like this, use
+-ffreestanding to tell LLVM we are not hosted so it is not free to make
+transformations like this.
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/647
+Link: https://github.com/llvm/llvm-project/commit/76cdcf25b883751d83402baea6316772aa73865c
+Reviewed-by: Nick Desaulneris <ndesaulniers@google.com>
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+Link: https://lore.kernel.org/lkml/20191014025101.18567-4-natechancellor@gmail.com/
+---
+ arch/powerpc/kernel/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/powerpc/kernel/Makefile b/arch/powerpc/kernel/Makefile
+index f1f362146135..7f0ee465dfb6 100644
+--- a/arch/powerpc/kernel/Makefile
++++ b/arch/powerpc/kernel/Makefile
+@@ -21,7 +21,7 @@ CFLAGS_prom_init.o += $(DISABLE_LATENT_ENTROPY_PLUGIN)
+ CFLAGS_btext.o += $(DISABLE_LATENT_ENTROPY_PLUGIN)
+ CFLAGS_prom.o += $(DISABLE_LATENT_ENTROPY_PLUGIN)
+ 
+-CFLAGS_prom_init.o += $(call cc-option, -fno-stack-protector)
++CFLAGS_prom_init.o += $(call cc-option, -fno-stack-protector) -ffreestanding
+ 
+ ifdef CONFIG_FUNCTION_TRACER
+ # Do not trace early boot code
+-- 
+2.23.0
+

--- a/patches/llvm-all/linux/ppc64/0001-powerpc-prom_init-Use-ffreestanding-to-avoid-a-refer.patch
+++ b/patches/llvm-all/linux/ppc64/0001-powerpc-prom_init-Use-ffreestanding-to-avoid-a-refer.patch
@@ -1,0 +1,49 @@
+From 1b98a48e312ac0be1746df53729fbb308a0c1ada Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <natechancellor@gmail.com>
+Date: Sun, 13 Oct 2019 19:51:01 -0700
+Subject: [PATCH] powerpc/prom_init: Use -ffreestanding to avoid a reference to
+ bcmp
+
+r374662 gives LLVM the ability to convert certain loops into a reference
+to bcmp as an optimization; this breaks prom_init_check.sh:
+
+  CALL    arch/powerpc/kernel/prom_init_check.sh
+Error: External symbol 'bcmp' referenced from prom_init.c
+make[2]: *** [arch/powerpc/kernel/Makefile:196: prom_init_check] Error 1
+
+bcmp is defined in lib/string.c as a wrapper for memcmp so this could be
+added to the whitelist. However, commit 450e7dd4001f ("powerpc/prom_init:
+don't use string functions from lib/") copied memcmp as prom_memcmp to
+avoid KASAN instrumentation so having bcmp be resolved to regular memcmp
+would break that assumption. Furthermore, because the compiler is the
+one that inserted bcmp, we cannot provide something like prom_bcmp.
+
+To prevent LLVM from being clever with optimizations like this, use
+-ffreestanding to tell LLVM we are not hosted so it is not free to make
+transformations like this.
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/647
+Link: https://github.com/llvm/llvm-project/commit/76cdcf25b883751d83402baea6316772aa73865c
+Reviewed-by: Nick Desaulneris <ndesaulniers@google.com>
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+Link: https://lore.kernel.org/lkml/20191014025101.18567-4-natechancellor@gmail.com/
+---
+ arch/powerpc/kernel/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/powerpc/kernel/Makefile b/arch/powerpc/kernel/Makefile
+index f1f362146135..7f0ee465dfb6 100644
+--- a/arch/powerpc/kernel/Makefile
++++ b/arch/powerpc/kernel/Makefile
+@@ -21,7 +21,7 @@ CFLAGS_prom_init.o += $(DISABLE_LATENT_ENTROPY_PLUGIN)
+ CFLAGS_btext.o += $(DISABLE_LATENT_ENTROPY_PLUGIN)
+ CFLAGS_prom.o += $(DISABLE_LATENT_ENTROPY_PLUGIN)
+ 
+-CFLAGS_prom_init.o += $(call cc-option, -fno-stack-protector)
++CFLAGS_prom_init.o += $(call cc-option, -fno-stack-protector) -ffreestanding
+ 
+ ifdef CONFIG_FUNCTION_TRACER
+ # Do not trace early boot code
+-- 
+2.23.0
+


### PR DESCRIPTION
Fixes:

* https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/245766675

* https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/245766684

Presubmit: https://travis-ci.com/nathanchance/continuous-integration/builds/132016071