### PR TITLE
travis: Use Xenial instead of Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,6 @@ matrix:
       if: type = cron
 compiler: gcc
 os: linux
-dist: trusty
 sudo: required
 cache:
   directories:


### PR DESCRIPTION
Xenial is now the default. While we don't use anything in this
environment, it is still good to get a newer version of Docker and other
host utilities should we ever need them.

Presubmit: https://travis-ci.com/nathanchance/continuous-integration/builds/132017016

Link: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment