### PR TITLE
remove `git` suffixes from clang version as well

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -252,7 +252,7 @@ check_dependencies() {
 # fall back to GNU ar and let them know.
 check_ar_version() {
   if ${AR} --version | grep -q "LLVM" && \
-     [[ $(${AR} --version | grep version | sed -e 's/.*LLVM version //g' -e 's/[[:blank:]]*$//' -e 's/\.//g' -e 's/svn//' ) -lt 900 ]]; then
+     [[ $(${AR} --version | grep version | sed -e 's/.*LLVM version //g' -e 's/[[:blank:]]*$//' -e 's/\.//g' -e 's/svn//' -e 's/git//' ) -lt 900 ]]; then
     set +x
     echo
     echo "${AR} found but appears to be too old to build the kernel (needs to be at least 9.0.0)."


### PR DESCRIPTION
fixes the observed warning:
./driver.sh: line 255: [[: 1000git: value too great for base (error token is "1000git")
which is my fault because I switched LLVM 10 to use `git` for suffixes
rather than `svn` for non-release (ie. local dev) builds.

Link: https://github.com/llvm/llvm-project/commit/49fb4a96e0b79e18aec0ed908676ae4ecaf3084b
Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>