### PR TITLE
Update travis configuration to pass new build config validation without warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-matrix:
+jobs:
   include:
     # linux
     - name: "ARCH=arm32_v5 LD=ld.lld"
@@ -166,7 +166,6 @@ matrix:
       if: type = cron
 compiler: gcc
 os: linux
-sudo: required
 cache:
   directories:
     - .ccache


### PR DESCRIPTION
Before this change travis config validation produces the following messages:

- `[WARN]` `root`: deprecated key `sudo` (The key `sudo` has no effect anymore.)
- `[INFO]` `root`: key `matrix` is an alias for `jobs`, using `jobs` 