### PR TITLE
Build RISC-V target only for -next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ jobs:
     - name: "ARCH=ppc64le LD=ld.lld REPO=linux-next"
       env: ARCH=ppc64le LD=ld.lld-11 REPO=linux-next
       if: type = cron
+    - name: "ARCH=riscv REPO=linux-next BOOT=0"
+      env: ARCH=riscv REPO=linux-next
+      if: type = cron
     - name: "ARCH=s390 BOOT=0 REPO=linux-next"
       env: ARCH=s390 REPO=linux-next
       if: type = cron

--- a/driver.sh
+++ b/driver.sh
@@ -149,6 +149,12 @@ setup_variables() {
       export ARCH=powerpc
       export CROSS_COMPILE=powerpc64le-linux-gnu- ;;
 
+    "riscv")
+      config=defconfig
+      image_name=vmlinux
+      using_qemu=false
+      export CROSS_COMPILE=riscv64-linux-gnu- ;;
+
     "s390")
         config=defconfig
         image_name=bzImage


### PR DESCRIPTION
As suggested in https://github.com/ClangBuiltLinux/continuous-integration/pull/70#issuecomment-599714608, RISC-V targets are only enabled on linux-next, so they would build fine without the patches. Build logs for these targets can be found [here](https://github.com/ClangBuiltLinux/continuous-integration/runs/512210549).