### PR TITLE
fix arm64 4.4 build

### DIFF
--- a/patches/llvm-11/4.4/arch-all/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch
+++ b/patches/llvm-11/4.4/arch-all/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch
@@ -31,13 +31,13 @@ Signed-off-by: David Gibson <david@gibson.dropbear.id.au>
 Cc: stable@vger.kernel.org
 Signed-off-by: Rob Herring <robh@kernel.org>
 ---
- scripts/dtc/dtc-lexer.l | 1 -
+ scripts/dtc/dtc-lexer.lex.c_shipped | 1 -
  1 file changed, 1 deletion(-)
 
-diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
 index 5c6c3fd557d7..b3b7270300de 100644
---- a/scripts/dtc/dtc-lexer.l
-+++ b/scripts/dtc/dtc-lexer.l
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
 @@ -23,7 +23,6 @@ LINECOMMENT	"//".*\n
  #include "srcpos.h"
  #include "dtc-parser.tab.h"


### PR DESCRIPTION
`$ cp patches/llvm-11/4.9/arch-all/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch patches/llvm-11/4.4/arch-all/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch`

Fixes: #239