### PR TITLE
remove arm64 default

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -40,8 +40,7 @@ setup_variables() {
   esac
   [[ -z "${url:-}" ]] && url=git://git.kernel.org/pub/scm/linux/kernel/git/${owner}/${tree}.git
 
-  # arm64 is the current default if nothing is specified
-  SUBARCH=${ARCH:=arm64}
+  SUBARCH=${ARCH}
   case ${SUBARCH} in
     "arm32_v5")
       config=multi_v5_defconfig

--- a/usage.txt
+++ b/usage.txt
@@ -13,9 +13,10 @@ Environment variables:
       If no AR value is specified, the script will attempt to set AR to
       llvm-ar-10 llvm-ar-9, llvm-ar-8, llvm-ar-7, llvm-ar, then
       ${CROSS_COMPILE}ar if they are found in PATH.
-  ARCH:
-      If no ARCH value is specified, arm64 is the default. Currently, arm32_v7,
-      arm32_v6, arm32_v5, arm64, ppc64le and x86_64 are supported.
+  ARCH (required):
+      If no ARCH value is specified, it's an error; there is no default.
+      Currently, arm32_v7, arm32_v6, arm32_v5, arm64, mips, mipsel, ppc32,
+      ppc64, ppc64le, s390, riscv, and x86_64 are supported.
   CC:
       If no CC value is specified, the script will attempt to set CC to
       clang-10, clang-9, clang-8, clang-7, then clang if they are found


### PR DESCRIPTION
This was useful back when arm64 was the only target we could reliably
build, but being explicit here is better and our .travis.yml already
passes an ARCH for all cases.