### PR TITLE
travis: Use integrated assembler for RISCV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ jobs:
     - name: "ARCH=ppc64le LD=ld.lld REPO=linux-next"
       env: ARCH=ppc64le LD=ld.lld REPO=linux-next
       if: type = cron
-    - name: "ARCH=riscv REPO=linux-next BOOT=0"
-      env: ARCH=riscv REPO=linux-next
+    - name: "ARCH=riscv AS=clang REPO=linux-next BOOT=0"
+      env: ARCH=riscv AS=clang REPO=linux-next
       if: type = cron
     - name: "ARCH=s390 BOOT=0 REPO=linux-next"
       env: ARCH=s390 REPO=linux-next


### PR DESCRIPTION
This works fine and avoids the error in the issue below.

Closes: https://github.com/ClangBuiltLinux/linux/issues/967
Presubmit: https://travis-ci.com/github/nathanchance/continuous-integration/builds/157639008