### PR TITLE
Enable LLD for MIPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ jobs:
       env: ARCH=arm32_v7 LD=ld.lld
     - name: "ARCH=arm64 LD=ld.lld"
       env: ARCH=arm64 LD=ld.lld
-    - name: "ARCH=mips"
-      env: ARCH=mips
-    - name: "ARCH=mipsel"
-      env: ARCH=mipsel
+    - name: "ARCH=mips LD=ld.lld"
+      env: ARCH=mips LD=ld.lld
+    - name: "ARCH=mipsel LD=ld.lld"
+      env: ARCH=mipsel LD=ld.lld
     - name: "ARCH=ppc32"
       env: ARCH=ppc32
     - name: "ARCH=ppc64"
@@ -39,11 +39,11 @@ jobs:
     - name: "ARCH=arm64 LD=ld.lld REPO=linux-next"
       env: ARCH=arm64 LD=ld.lld REPO=linux-next
       if: type = cron
-    - name: "ARCH=mips REPO=linux-next"
-      env: ARCH=mips REPO=linux-next
+    - name: "ARCH=mips LD=ld.lld REPO=linux-next"
+      env: ARCH=mips LD=ld.lld REPO=linux-next
       if: type = cron
-    - name: "ARCH=mipsel REPO=linux-next"
-      env: ARCH=mipsel REPO=linux-next
+    - name: "ARCH=mipsel LD=ld.lld REPO=linux-next"
+      env: ARCH=mipsel LD=ld.lld REPO=linux-next
       if: type = cron
     - name: "ARCH=ppc32 REPO=linux-next"
       env: ARCH=ppc32 REPO=linux-next
@@ -70,11 +70,11 @@ jobs:
     - name: "ARCH=arm64 LD=ld.lld REPO=5.4"
       env: ARCH=arm64 LD=ld.lld REPO=5.4
       if: type = cron
-    - name: "ARCH=mips REPO=5.4"
-      env: ARCH=mips REPO=5.4
+    - name: "ARCH=mips LD=ld.lld REPO=5.4"
+      env: ARCH=mips LD=ld.lld REPO=5.4
       if: type = cron
-    - name: "ARCH=mipsel REPO=5.4"
-      env: ARCH=mipsel REPO=5.4
+    - name: "ARCH=mipsel LD=ld.lld REPO=5.4"
+      env: ARCH=mipsel LD=ld.lld REPO=5.4
       if: type = cron
     - name: "ARCH=ppc32 REPO=5.4"
       env: ARCH=ppc32 REPO=5.4

--- a/driver.sh
+++ b/driver.sh
@@ -74,13 +74,13 @@ setup_variables() {
       export CROSS_COMPILE=aarch64-linux-gnu- ;;
 
     "mips")
-      config=malta_defconfig
+      config=malta_kvm_guest_defconfig
       make_target=vmlinux
       export ARCH=mips
       export CROSS_COMPILE=mips-linux-gnu- ;;
 
     "mipsel")
-      config=malta_defconfig
+      config=malta_kvm_guest_defconfig
       make_target=vmlinux
       export ARCH=mips
       export CROSS_COMPILE=mipsel-linux-gnu- ;;


### PR DESCRIPTION
By switching to `malta_kvm_guest_defconfig`, we can enable `ld.lld` now. See individual commit messages for reasoning.

Presubmit: https://travis-ci.com/github/nathanchance/continuous-integration/builds/158431604