### PR TITLE
driver: Move to GNU objcopy for arm32_v5 for now

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -55,6 +55,9 @@ setup_variables() {
             make_target=zImage
             export ARCH=arm
             export CROSS_COMPILE=arm-linux-gnueabi-
+
+            # https://bugs.llvm.org/show_bug.cgi?id=45632
+            OBJCOPY=${CROSS_COMPILE}objcopy
             ;;
 
         "arm32_v6")


### PR DESCRIPTION
There appears to be a bug in llvm-objcopy that was exposed by increasing
the page size to 64K for 32-bit ARM.

Move to GNU objcopy until that it fixed.

Presubmit: https://travis-ci.com/github/nathanchance/continuous-integration/builds/162491349