### PR TITLE
Revert "driver: Move to GNU objcopy for arm32_v5 for now"

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -55,9 +55,6 @@ setup_variables() {
             make_target=zImage
             export ARCH=arm
             export CROSS_COMPILE=arm-linux-gnueabi-
-
-            # https://bugs.llvm.org/show_bug.cgi?id=45632
-            OBJCOPY=${CROSS_COMPILE}objcopy
             ;;
 
         "arm32_v6")


### PR DESCRIPTION
This reverts commit 4db0c1e19f8dc7ee6f9ae8ae50d20930ba689c39.

The issue has been fixed and the fix is available in the version of
LLVM that our Docker container uses:

https://github.com/llvm/llvm-project/commits/cc1c5165585/llvm/tools/llvm-objcopy
https://github.com/llvm/llvm-project/commit/ec786906f5feb4dceba1b5338927079e63e78095
Presubmit: https://travis-ci.com/github/nathanchance/continuous-integration/builds/163450700