### PR TITLE
Allow objcopy and strip binaries to be specified

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -5,7 +5,7 @@ set -eu
 setup_variables() {
     while [[ ${#} -ge 1 ]]; do
         case ${1} in
-            "AR="* | "ARCH="* | "CC="* | "LD="* | "LLVM_IAS="* | "NM"=* | "OBJDUMP"=* | "OBJSIZE"=* | "REPO="*) export "${1?}" ;;
+            "AR="* | "ARCH="* | "CC="* | "LD="* | "LLVM_IAS="* | "NM"=* | "OBJCOPY"=* | "OBJDUMP"=* | "OBJSIZE"=* | "REPO="* | "STRIP"=*) export "${1?}" ;;
             "-c" | "--clean") cleanup=true ;;
             "-j" | "--jobs")
                 shift


### PR DESCRIPTION
https://github.com/ClangBuiltLinux/continuous-integration/pull/253 added support for `objcopy` and `strip` utilities, but they couldn't be specified on the command line.