### PR TITLE
Enable integrated-as on selected arches on linux-next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ jobs:
     # linux (cron only)
     #
     # linux-next (cron only)
-    - name: "ARCH=arm32_v5 LD=ld.lld REPO=linux-next"
-      env: ARCH=arm32_v5 LD=ld.lld REPO=linux-next
+    - name: "ARCH=arm32_v5 LD=ld.lld LLVM_IAS=1 REPO=linux-next"
+      env: ARCH=arm32_v5 LD=ld.lld LLVM_IAS=1 REPO=linux-next
       if: type = cron
     - name: "ARCH=arm32_v6 REPO=linux-next"
       env: ARCH=arm32_v6 REPO=linux-next
@@ -40,8 +40,8 @@ jobs:
     - name: "ARCH=arm32_v7 LD=ld.lld REPO=linux-next"
       env: ARCH=arm32_v7 LD=ld.lld REPO=linux-next
       if: type = cron
-    - name: "ARCH=arm64 LD=ld.lld REPO=linux-next"
-      env: ARCH=arm64 LD=ld.lld REPO=linux-next
+    - name: "ARCH=arm64 LD=ld.lld LLVM_IAS=1 REPO=linux-next"
+      env: ARCH=arm64 LD=ld.lld LLVM_IAS=1 REPO=linux-next
       if: type = cron
     - name: "ARCH=mips LD=ld.lld REPO=linux-next"
       env: ARCH=mips LD=ld.lld REPO=linux-next
@@ -64,11 +64,11 @@ jobs:
     - name: "ARCH=s390 BOOT=0 REPO=linux-next"
       env: ARCH=s390 REPO=linux-next
       if: type = cron
-    - name: "ARCH=x86 LD=ld.lld REPO=linux-next"
-      env: ARCH=x86 LD=ld.lld REPO=linux-next
+    - name: "ARCH=x86 LD=ld.lld LLVM_IAS=1 REPO=linux-next"
+      env: ARCH=x86 LD=ld.lld LLVM_IAS=1 REPO=linux-next
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=linux-next"
-      env: ARCH=x86_64 LD=ld.lld REPO=linux-next
+    - name: "ARCH=x86_64 LD=ld.lld LLVM_IAS=1 REPO=linux-next"
+      env: ARCH=x86_64 LD=ld.lld LLVM_IAS=1 REPO=linux-next
       if: type = cron
     # stable
     - name: "ARCH=arm32_v7 LD=ld.lld REPO=5.4"

--- a/patches/llvm-all/linux-next/arm64/silence-dwarf2-warnings.patch
+++ b/patches/llvm-all/linux-next/arm64/silence-dwarf2-warnings.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index 11fe9b1535de..3c6e0ae33d74 100644
+--- a/Makefile
++++ b/Makefile
+@@ -803,8 +803,10 @@ DEBUG_CFLAGS	+= -gsplit-dwarf
+ else
+ DEBUG_CFLAGS	+= -g
+ endif
++ifndef LLVM_IAS
+ KBUILD_AFLAGS	+= -Wa,-gdwarf-2
+ endif
++endif
+ ifdef CONFIG_DEBUG_INFO_DWARF4
+ DEBUG_CFLAGS	+= -gdwarf-4
+ endif


### PR DESCRIPTION
As seen [here](https://travis-ci.com/github/ClangBuiltLinux/continuous-integration/builds/164981592), arm32_v5, arm64, x86 and x86_64 already have all necessary patches on linux-next to be built with integrated-as enabled. ARM64 still produces a lot of warnings due to https://github.com/ClangBuiltLinux/linux/issues/716.