### PR TITLE
travis: Move MIPS big endian to ld.bfd on -next for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ jobs:
     - name: "ARCH=arm64 LD=ld.lld LLVM_IAS=1 REPO=linux-next"
       env: ARCH=arm64 LD=ld.lld LLVM_IAS=1 REPO=linux-next
       if: type = cron
-    - name: "ARCH=mips LD=ld.lld REPO=linux-next"
-      env: ARCH=mips LD=ld.lld REPO=linux-next
+    - name: "ARCH=mips REPO=linux-next"
+      env: ARCH=mips REPO=linux-next
       if: type = cron
     - name: "ARCH=mipsel LD=ld.lld REPO=linux-next"
       env: ARCH=mipsel LD=ld.lld REPO=linux-next


### PR DESCRIPTION
The series to fix https://github.com/ClangBuiltLinux/linux/issues/785
exposed an issue with ld.lld, which breaks the build.

Move this target to ld.bfd while we discuss how to fix it so that this
target is not blocked for testing.

Link: https://github.com/ClangBuiltLinux/linux/issues/1025
Presubmit: https://travis-ci.com/github/nathanchance/continuous-integration/builds/166566747