### PR TITLE
driver.sh: Build uImage for ppc32

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -102,7 +102,7 @@ setup_variables() {
 
         "ppc32")
             config=ppc44x_defconfig
-            make_target=zImage
+            make_target=uImage
             export ARCH=powerpc
             export CROSS_COMPILE=powerpc-linux-gnu-
             ;;


### PR DESCRIPTION
zImage has always been a hardlink to uImage but as of a refactoring in
5.8-rc1, that is no longer guaranteed to be the case. Explicitly build
the uImage so that we can always boot with QEMU.

Link: https://lore.kernel.org/linuxppc-dev/87bllidmk4.fsf@mpe.ellerman.id.au/