### PR TITLE
Increase aarch64 timeout from 2m to 3m

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -83,6 +83,7 @@ setup_variables() {
                 *) config=defconfig ;;
             esac
             make_target=Image.gz
+            timeout=5 # Bump the timeout to 5m.
             export CROSS_COMPILE=aarch64-linux-gnu-
             ;;
 


### PR DESCRIPTION
Fixes: https://github.com/ClangBuiltLinux/linux/issues/1058
Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>