### PR TITLE
travis: Disable the integrated assembler for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ jobs:
     - name: "ARCH=arm32_v7 LD=ld.lld REPO=linux-next"
       env: ARCH=arm32_v7 LD=ld.lld REPO=linux-next
       if: type = cron
-    - name: "ARCH=arm64 LD=ld.lld LLVM_IAS=1 REPO=linux-next"
-      env: ARCH=arm64 LD=ld.lld LLVM_IAS=1 REPO=linux-next
+    - name: "ARCH=arm64 LD=ld.lld REPO=linux-next"
+      env: ARCH=arm64 LD=ld.lld REPO=linux-next
       if: type = cron
     - name: "ARCH=mips REPO=linux-next"
       env: ARCH=mips REPO=linux-next


### PR DESCRIPTION
Note, as of next-20200707, arm32 and arm64 boot is broken but should be
fixed in next-20200708 for reasons unrelated to LLVM:

https://lore.kernel.org/dmaengine/5f036d83.1c69fb81.10199.06d0@mx.google.com/
https://lore.kernel.org/dmaengine/159404871194.45151.3076873396834992441.stgit@djiang5-desk3.ch.intel.com/

No presubmit testing is done for that reason but this has been verified
locally.

Fixes: https://travis-ci.com/github/ClangBuiltLinux/continuous-integration/jobs/358277535
Link: https://github.com/ClangBuiltLinux/linux/issues/1078