### PR TITLE
ci: Update certain Android branches for recent upstream changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,11 +135,11 @@ jobs:
     - name: "ARCH=arm64 REPO=android-4.14-stable"
       env: ARCH=arm64 REPO=android-4.14-stable
       if: type = cron
-    - name: "ARCH=arm64 REPO=android-4.19"
-      env: ARCH=arm64 REPO=android-4.19
+    - name: "ARCH=arm64 REPO=android-4.19-stable"
+      env: ARCH=arm64 REPO=android-4.19-stable
       if: type = cron
-    - name: "ARCH=arm64 REPO=android-5.4"
-      env: ARCH=arm64 REPO=android-5.4
+    - name: "ARCH=arm64 REPO=android12-5.4"
+      env: ARCH=arm64 REPO=android12-5.4
       if: type = cron
     - name: "ARCH=arm64 REPO=android-mainline"
       env: ARCH=arm64 REPO=android-mainline
@@ -150,11 +150,11 @@ jobs:
     - name: "ARCH=x86_64 LD=ld.lld REPO=android-4.14-stable"
       env: ARCH=x86_64 LD=ld.lld REPO=android-4.14-stable
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=android-4.19"
-      env: ARCH=x86_64 LD=ld.lld REPO=android-4.19
+    - name: "ARCH=x86_64 LD=ld.lld REPO=android-4.19-stable"
+      env: ARCH=x86_64 LD=ld.lld REPO=android-4.19-stable
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=android-5.4"
-      env: ARCH=x86_64 LD=ld.lld REPO=android-5.4
+    - name: "ARCH=x86_64 LD=ld.lld REPO=android12-5.4"
+      env: ARCH=x86_64 LD=ld.lld REPO=android12-5.4
       if: type = cron
     - name: "ARCH=x86_64 LD=ld.lld REPO=android-mainline"
       env: ARCH=x86_64 LD=ld.lld REPO=android-mainline

--- a/driver.sh
+++ b/driver.sh
@@ -27,7 +27,7 @@ setup_variables() {
 
     # torvalds/linux is the default repo if nothing is specified
     case ${REPO:=linux} in
-        "android-"*)
+        "android"*)
             tree=common
             branch=${REPO}
             url=https://android.googlesource.com/kernel/${tree}


### PR DESCRIPTION
android-4.19 has been moved to deprecated/android-4.19, meaning it will
no longer see updates. android-4.19-stable should be the equivalent
(similar to android-4.14-stable):

https://android-review.googlesource.com/c/kernel/manifest/+/1359844

Fixes the following builds:

https://travis-ci.com/github/ClangBuiltLinux/continuous-integration/jobs/359204121
https://travis-ci.com/github/ClangBuiltLinux/continuous-integration/jobs/359204126

Additionally, android-5.4 has been shuffled to android12-5.4:

https://android-review.googlesource.com/c/kernel/manifest/+/1358083
https://android-review.googlesource.com/c/kernel/manifest/+/1358088

android-5.4 still technically exists but do not rely on that always
being true and just do that change now so that we do not have to do it
later when the build breaks.

Presubmit: https://travis-ci.com/github/nathanchance/continuous-integration/builds/175084826