### PR TITLE
driver: Don't skip ftrace on arm32

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -398,8 +398,6 @@ build_linux() {
         cat ../configs/common.config >>.config
         # Some torture test configs cause issues on PowerPC and x86_64
         [[ $ARCH != "x86_64" && $ARCH != "powerpc" ]] && cat ../configs/tt.config >>.config
-        # Disable ftrace on arm32: https://github.com/ClangBuiltLinux/linux/issues/35
-        [[ $ARCH == "arm" ]] && ./scripts/config -d CONFIG_FTRACE
         # Disable LTO and CFI unless explicitly requested
         ${disable_lto:=true} && ./scripts/config -d CONFIG_LTO -d CONFIG_LTO_CLANG
     fi


### PR DESCRIPTION
The referenced issue https://github.com/ClangBuiltLinux/linux/issues/35
was fixed in 2019 when clang 10 gained support for this feature on arm.

Signed-off-by: Joel Stanley <joel@jms.id.au>