### PR TITLE
Revert "travis: Disable booting for RISC-V on linux-next for now"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,8 @@ jobs:
     - name: "ARCH=ppc64le LD=ld.lld REPO=linux-next"
       env: ARCH=ppc64le LD=ld.lld REPO=linux-next
       if: type = cron
-    - name: "ARCH=riscv BOOT=false LLVM_IAS=1 REPO=linux-next"
-      env: ARCH=riscv BOOT=false LLVM_IAS=1 REPO=linux-next
+    - name: "ARCH=riscv LLVM_IAS=1 REPO=linux-next"
+      env: ARCH=riscv LLVM_IAS=1 REPO=linux-next
       if: type = cron
     - name: "ARCH=s390 BOOT=false REPO=linux-next"
       env: ARCH=s390 REPO=linux-next BOOT=false


### PR DESCRIPTION
This reverts commit 590e48344c13e5910021b7cd1268dd93b8ab96b7.

This has been fixed: https://github.com/ClangBuiltLinux/linux/issues/1092

Unfortunately, the build will still be broken; still pending
investigation. I am only doing this so that I do not forget.