### PR TITLE
RISC-V fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ jobs:
       env: ARCH=ppc64
     - name: "ARCH=ppc64le LD=ld.lld"
       env: ARCH=ppc64le LD=ld.lld
-    - name: "ARCH=riscv LLVM_IAS=1"
-      env: ARCH=riscv LLVM_IAS=1
+    - name: "ARCH=riscv BOOT=false LLVM_IAS=1"
+      env: ARCH=riscv BOOT=false LLVM_IAS=1
     - name: "ARCH=s390 BOOT=false"
       env: ARCH=s390 BOOT=false
     - name: "ARCH=x86 LLVM=1"
@@ -58,8 +58,8 @@ jobs:
     - name: "ARCH=ppc64le LD=ld.lld REPO=linux-next"
       env: ARCH=ppc64le LD=ld.lld REPO=linux-next
       if: type = cron
-    - name: "ARCH=riscv LLVM_IAS=1 REPO=linux-next"
-      env: ARCH=riscv LLVM_IAS=1 REPO=linux-next
+    - name: "ARCH=riscv BOOT=false LLVM_IAS=1 REPO=linux-next"
+      env: ARCH=riscv BOOT=false LLVM_IAS=1 REPO=linux-next
       if: type = cron
     - name: "ARCH=s390 BOOT=false REPO=linux-next"
       env: ARCH=s390 REPO=linux-next BOOT=false

--- a/driver.sh
+++ b/driver.sh
@@ -414,6 +414,19 @@ build_linux() {
         cat ../configs/common.config >>.config
         # Some torture test configs cause issues on PowerPC and x86_64
         [[ $ARCH != "x86_64" && $ARCH != "powerpc" ]] && cat ../configs/tt.config >>.config
+        # For RISC-V, disable a couple of configs:
+        # * CONFIG_EFI: https://github.com/ClangBuiltLinux/linux/issues/1143
+        # * CONFIG_KALLSYMS_ALL: https://github.com/ClangBuiltLinux/linux/issues/1144
+        # Every other configuration option disabled is to get rid of CONFIG_KALLSYMS_ALL.
+        if [[ $ARCH = "riscv" ]]; then
+            ./scripts/config \
+                -d DEBUG_LOCK_ALLOC \
+                -d DEBUG_WW_MUTEX_SLOWPATH \
+                -d EFI \
+                -d KALLSYMS_ALL \
+                -d LOCK_STAT \
+                -d PROVE_LOCKING
+        fi
         # Disable LTO and CFI unless explicitly requested
         ${disable_lto:=true} && ./scripts/config -d CONFIG_LTO -d CONFIG_LTO_CLANG
     fi

--- a/patches/llvm-all/linux-next/riscv/setup.c.patch
+++ b/patches/llvm-all/linux-next/riscv/setup.c.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/riscv/kernel/setup.c b/arch/riscv/kernel/setup.c
+index 5ab185130cae..41ef96d0d97a 100644
+--- a/arch/riscv/kernel/setup.c
++++ b/arch/riscv/kernel/setup.c
+@@ -19,6 +19,7 @@
+ #include <linux/smp.h>
+ 
+ #include <asm/cpu_ops.h>
++#include <asm/early_ioremap.h>
+ #include <asm/setup.h>
+ #include <asm/sections.h>
+ #include <asm/sbi.h>


### PR DESCRIPTION
This pull "fixes" RISC-V builds and should make the build fully green.

Presubmit: https://travis-ci.com/github/nathanchance/continuous-integration/builds/181740252

The first two patches workaround https://github.com/ClangBuiltLinux/linux/issues/1143 and https://github.com/ClangBuiltLinux/linux/issues/1144. `BOOT=false` is necessary because the QEMU shipped in Ubuntu/Debian appears to be bugged as stock QEMU 4.2.0 and 5.0.0 work fine. We could probably start building QEMU in our Docker image but that is a significant amount of overhead and yet another binary that we have to triage issues with.

An alternative to this is just dropping RISC-V support for the time being until the architecture has matured a bit more. I do not personally care either way but we should really get the whole matrix fully green at this point.