### PR TITLE
driver: Increase timeout for arm64 to 8m

### DIFF
--- a/driver.sh
+++ b/driver.sh
@@ -88,7 +88,7 @@ setup_variables() {
                 *) config=defconfig ;;
             esac
             make_target=Image.gz
-            timeout=5 # Bump the timeout to 5m.
+            timeout=8 # '-cpu max' with QEMU takes longer to boot, increase timeout to 8m for Travis
             export CROSS_COMPILE=aarch64-linux-gnu-
             ;;
 


### PR DESCRIPTION
arm64 builds have recently been timing out during boot on mainline and
next, regardless of LLVM version. It is possible this is something that
should be investigated on the kernel side but local reproduction is a
bit more difficult due to higher power cores than what are available on
Travis. Just increase the timeout to 8m to be sure that we are hung.

Presubmit: https://travis-ci.com/github/nathanchance/continuous-integration/builds/183784691