### PR TITLE
expand LLVM=1 coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,11 +135,11 @@ jobs:
     - name: "ARCH=arm64 REPO=android-4.14-stable"
       env: ARCH=arm64 REPO=android-4.14-stable
       if: type = cron
-    - name: "ARCH=arm64 REPO=android-4.19-stable"
-      env: ARCH=arm64 REPO=android-4.19-stable
+    - name: "ARCH=arm64 LLVM=1 REPO=android-4.19-stable"
+      env: ARCH=arm64 LLVM=1 REPO=android-4.19-stable
       if: type = cron
-    - name: "ARCH=arm64 REPO=android12-5.4"
-      env: ARCH=arm64 REPO=android12-5.4
+    - name: "ARCH=arm64 LLVM=1 REPO=android12-5.4"
+      env: ARCH=arm64 LLVM=1 REPO=android12-5.4
       if: type = cron
     - name: "ARCH=arm64 LLVM=1 LLVM_IAS=1 REPO=android-mainline"
       env: ARCH=arm64 LLVM=1 LLVM_IAS=1 REPO=android-mainline
@@ -150,11 +150,11 @@ jobs:
     - name: "ARCH=x86_64 LD=ld.lld REPO=android-4.14-stable"
       env: ARCH=x86_64 LD=ld.lld REPO=android-4.14-stable
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=android-4.19-stable"
-      env: ARCH=x86_64 LD=ld.lld REPO=android-4.19-stable
+    - name: "ARCH=x86_64 LLVM=1 REPO=android-4.19-stable"
+      env: ARCH=x86_64 LLVM=1 REPO=android-4.19-stable
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=android12-5.4"
-      env: ARCH=x86_64 LD=ld.lld REPO=android12-5.4
+    - name: "ARCH=x86_64 LLVM=1 REPO=android12-5.4"
+      env: ARCH=x86_64 LLVM=1 REPO=android12-5.4
       if: type = cron
     - name: "ARCH=x86_64 LLVM=1 LLVM_IAS=1 REPO=android-mainline"
       env: ARCH=x86_64 LLVM=1 LLVM_IAS=1 REPO=android-mainline

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: cpp
 jobs:
   include:
     # linux
-    - name: "ARCH=arm32_v5 LLVM=1"
-      env: ARCH=arm32_v5 LLVM=1
+    - name: "ARCH=arm32_v5 LLVM=1 LLVM_IAS=1"
+      env: ARCH=arm32_v5 LLVM=1 LLVM_IAS=1
     - name: "ARCH=arm32_v6"
       env: ARCH=arm32_v6
     - name: "ARCH=arm32_v7 LLVM=1"
@@ -31,14 +31,14 @@ jobs:
     # linux (cron only)
     #
     # linux-next (cron only)
-    - name: "ARCH=arm32_v5 LD=ld.lld LLVM_IAS=1 REPO=linux-next"
-      env: ARCH=arm32_v5 LD=ld.lld LLVM_IAS=1 REPO=linux-next
+    - name: "ARCH=arm32_v5 LLVM=1 LLVM_IAS=1 REPO=linux-next"
+      env: ARCH=arm32_v5 LLVM=1 LLVM_IAS=1 REPO=linux-next
       if: type = cron
     - name: "ARCH=arm32_v6 REPO=linux-next"
       env: ARCH=arm32_v6 REPO=linux-next
       if: type = cron
-    - name: "ARCH=arm32_v7 LD=ld.lld REPO=linux-next"
-      env: ARCH=arm32_v7 LD=ld.lld REPO=linux-next
+    - name: "ARCH=arm32_v7 LLVM=1 REPO=linux-next"
+      env: ARCH=arm32_v7 LLVM=1 REPO=linux-next
       if: type = cron
     - name: "ARCH=arm64 LLVM=1 REPO=linux-next"
       env: ARCH=arm64 LLVM=1 REPO=linux-next
@@ -71,11 +71,11 @@ jobs:
       env: ARCH=x86_64 LLVM=1 LLVM_IAS=1 REPO=linux-next
       if: type = cron
     # stable
-    - name: "ARCH=arm32_v7 LD=ld.lld REPO=5.4"
-      env: ARCH=arm32_v7 LD=ld.lld REPO=5.4
+    - name: "ARCH=arm32_v7 LLVM=1 REPO=5.4"
+      env: ARCH=arm32_v7 LLVM=1 REPO=5.4
       if: type = cron
-    - name: "ARCH=arm64 LD=ld.lld REPO=5.4"
-      env: ARCH=arm64 LD=ld.lld REPO=5.4
+    - name: "ARCH=arm64 LLVM=1 REPO=5.4"
+      env: ARCH=arm64 LLVM=1 REPO=5.4
       if: type = cron
     - name: "ARCH=mips LD=ld.lld REPO=5.4"
       env: ARCH=mips LD=ld.lld REPO=5.4
@@ -86,20 +86,20 @@ jobs:
     - name: "ARCH=ppc32 REPO=5.4"
       env: ARCH=ppc32 REPO=5.4
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=5.4"
-      env: ARCH=x86_64 LD=ld.lld REPO=5.4
+    - name: "ARCH=x86_64 LLVM=1 REPO=5.4"
+      env: ARCH=x86_64 LLVM=1 REPO=5.4
       if: type = cron
-    - name: "ARCH=arm32_v7 REPO=4.19"
-      env: ARCH=arm32_v7 REPO=4.19
+    - name: "ARCH=arm32_v7 LLVM=1 REPO=4.19"
+      env: ARCH=arm32_v7 LLVM=1 REPO=4.19
       if: type = cron
-    - name: "ARCH=arm64 LD=ld.lld REPO=4.19"
-      env: ARCH=arm64 LD=ld.lld REPO=4.19
+    - name: "ARCH=arm64 LLVM=1 REPO=4.19"
+      env: ARCH=arm64 LLVM=1 REPO=4.19
       if: type = cron
     - name: "ARCH=ppc64le REPO=4.19"
       env: ARCH=ppc64le REPO=4.19
       if: type = cron
-    - name: "ARCH=x86_64 LD=ld.lld REPO=4.19"
-      env: ARCH=x86_64 LD=ld.lld REPO=4.19
+    - name: "ARCH=x86_64 LLVM=1 REPO=4.19"
+      env: ARCH=x86_64 LLVM=1 REPO=4.19
       if: type = cron
     - name: "ARCH=arm32_v7 REPO=4.14"
       env: ARCH=arm32_v7 REPO=4.14


### PR DESCRIPTION
Tested locally; we could probably go further but I only tested LLVM=1
for arm32_v7, arm64, and x86_64 back to 4.19.

Also, LLVM_IAS=1 works on mainline for arm32_v5.

Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>