### PR TITLE
boot test s390

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ jobs:
       env: ARCH=ppc64le LD=ld.lld
     - name: "ARCH=riscv BOOT=false LLVM_IAS=1"
       env: ARCH=riscv BOOT=false LLVM_IAS=1
-    - name: "ARCH=s390 BOOT=false"
-      env: ARCH=s390 BOOT=false
+    - name: "ARCH=s390"
+      env: ARCH=s390
     - name: "ARCH=x86 LLVM=1 LLVM_IAS=1"
       env: ARCH=x86 LLVM=1 LLVM_IAS=1
     - name: "ARCH=x86_64 LLVM=1 LLVM_IAS=1"
@@ -61,8 +61,8 @@ jobs:
     - name: "ARCH=riscv BOOT=false LLVM_IAS=1 REPO=linux-next"
       env: ARCH=riscv BOOT=false LLVM_IAS=1 REPO=linux-next
       if: type = cron
-    - name: "ARCH=s390 BOOT=false REPO=linux-next"
-      env: ARCH=s390 REPO=linux-next BOOT=false
+    - name: "ARCH=s390 REPO=linux-next"
+      env: ARCH=s390 REPO=linux-next
       if: type = cron
     - name: "ARCH=x86 LLVM=1 LLVM_IAS=1 REPO=linux-next"
       env: ARCH=x86 LLVM=1 LLVM_IAS=1 REPO=linux-next


### PR DESCRIPTION
Now that we have the buildroot image, we can boot test.

Fixes: https://github.com/ClangBuiltLinux/continuous-integration/issues/232
Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>